### PR TITLE
Normative: Use locale internal slots for construction

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -230,15 +230,11 @@ contributors: Mozilla, Ecma International
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-Intl.Locale.prototype.toString">
-      <h1>Intl.Locale.prototype.toString ()</h1>
-
-      <p>
-      </p>
+    <emu-clause id="sec-locale-to-string" aoid=LocaleToString>
+      <h1>LocaleToString ( loc )</h1>
 
       <emu-alg>
-      1. Let _loc_ be the *this* value.
-      1. If Type(_loc_) does not have an [[InitializedLocale]] internal slot, throw a *TypeError* exception.
+      1. Assert: _loc_ has an [[InitializedLocale]] internal slot.
       1. Let _locale_ be _loc_.[[Locale]].
       1. Let _unicodeExt_ be an empty String.
       1. For each row in <emu-xref href="#table-locale-options"></emu-xref>, except the header row, do:
@@ -253,6 +249,16 @@ contributors: Mozilla, Ecma International
         1. Return _result_.
       1. Else,
         1. Return _locale_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-Intl.Locale.prototype.toString">
+      <h1>Intl.Locale.prototype.toString ()</h1>
+
+      <emu-alg>
+      1. Let _loc_ be the *this* value.
+      1. If Type(_loc_) is not Object, or _loc_ does not have an [[InitializedLocale]] internal slot, throw a *TypeError* exception.
+      1. Return LocaleToString(_loc_).
       </emu-alg>
     </emu-clause>
 
@@ -356,4 +362,47 @@ contributors: Mozilla, Ecma International
       </emu-alg>
     </emu-clause>
   </emu-clause>
+</emu-clause>
+
+<emu-clause id="sec-locale-modified-algorithms">
+  <h1>Modified algorithms</h1>
+
+    <emu-clause id="sec-canonicalizelocalelist" aoid="CanonicalizeLocaleList">
+      <h1>CanonicalizeLocaleList ( _locales_ )</h1>
+
+      <p>
+        The abstract operation CanonicalizeLocaleList takes the following steps:
+      </p>
+
+      <emu-alg>
+        1. If _locales_ is *undefined*, then
+          1. Return a new empty List.
+        1. Let _seen_ be a new empty List.
+        1. If Type(_locales_) is String, then
+          1. Let _O_ be CreateArrayFromList(&laquo; _locales_ &raquo;).
+        1. Else,
+          1. Let _O_ be ? ToObject(_locales_).
+        1. Let _len_ be ? ToLength(? Get(_O_, `"length"`)).
+        1. Let _k_ be 0.
+        1. Repeat, while _k_ < _len_
+          1. Let _Pk_ be ToString(_k_).
+          1. Let _kPresent_ be ? HasProperty(_O_, _Pk_).
+          1. If _kPresent_ is *true*, then
+            1. Let _kValue_ be ? Get(_O_, _Pk_).
+            1. If Type(_kValue_) is not String or Object, throw a *TypeError* exception.
+            1. <ins>If Type(_kValue_) is Object and _kValue_ has an [[InitializedLocale]] internal slot,</ins>
+              1. <ins>Let _tag_ be LocaleToString(_kValue_).</ins>
+            1. <ins>Otherwise,</ins>
+              1. Let _tag_ be ? ToString(_kValue_).
+            1. If IsStructurallyValidLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
+            1. Let _canonicalizedTag_ be CanonicalizeLanguageTag(_tag_).
+            1. If _canonicalizedTag_ is not an element of _seen_, append _canonicalizedTag_ as the last element of _seen_.
+          1. Increase _k_ by 1.
+        1. Return _seen_.
+      </emu-alg>
+
+      <emu-note type=editor>
+        When integrating into the main specification, the Intl.Locale object handling in this algorithm may be refactored to turn all strings into Intl.Locale instances, moving logic from ResolveLocale. This will be an editorial cleanup.
+      </emu-note>
+    </emu-clause>
 </emu-clause>


### PR DESCRIPTION
When a Intl object (e.g., a formatter) is constructed, if an
Intl.Locale object is passed as a parameter, treat the Locale as
it is represented in internal slots, rather than invoking a
(potentially modified) toString method. This patch is written
in terms of converting the Locale to a String in a fixed way,
before it gets reparsed; the specification would probably
benefit from a follow-on editorial change to refactor ResolveLocale
to deal in terms of Locale objects instead.

Closes #9