### PR TITLE
Various spec fixes

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -69,22 +69,19 @@ contributors: Mozilla, Ecma International
         1. Assert: Type(_tag_) is String.
         1. If IsStructurallyValidLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
         1. If _tag_ matches the `langtag` production, then
-          1. Let _language_ be ? Get(_options_, `"language"`).
+          1. Let _language_ be ? GetOption(_options_, `"language"`, `"string"`, *undefined*, *undefined*).
           1. If _language_ is not *undefined*, then
-            1. Set _language_ to ? ToString(_language_).
             1. If _language_ does not match the `language` production, throw a *RangeError* exception.
             1. Set _tag_ to _tag_ with the substring corresponding to the `language` production replaced by the string _language_.
-          1. Let _script_ be ? Get(_options_, `"script"`).
+          1. Let _script_ be ? GetOption(_options_, `"script"`, `"string"`, *undefined*, *undefined*).
           1. If _script_ is not *undefined*, then
-            1. Set _script_ to ? ToString(_script_).
             1. If _script_ does not match the `script` production, throw a *RangeError* exception.
             1. If _tag_ does not contain a `script` production, then
               1. Set _tag_ to the concatenation of the `language` production of _tag_, `"-"`, _script_, and the rest of _tag_.
             1. Else,
               1. Set _tag_ to _tag_ with the substring corresponding to the `script` production replaced by the string _script_.
-          1. Let _region_ be ? Get(_options_, `"region"`).
+          1. Let _region_ be ? GetOption(_options_, `"region"`, `"string"`, *undefined*, *undefined*).
           1. If _region_ is not *undefined*, then
-            1. Set _region_ to ? ToString(_region_).
             1. If _region_ does not match the `region` production, throw a *RangeError* exception.
             1. If _tag_ does not contain a `region` production, then
               1. Set _tag_ to the concatenation of the `language` production of _tag_, the substring corresponding to the `"-" script` production if present, `"-"`, _region_, and the rest of _tag_.
@@ -176,11 +173,9 @@ contributors: Mozilla, Ecma International
         1. Let _requestedLocales_ be ? CreateArrayFromList(&laquo; _tag_ &raquo;).
         1. Let _opt_ be a new Record.
         1. Set _opt_.[[localeMatcher]] to `"best fit"`.
-        1. Let _calendar_ be ? Get(_options_, `"calendar"`).
-        1. If _calendar_ is not *undefined*, set _calendar_ to ? ToString(_calendar_).
+        1. Let _calendar_ be ? GetOption(_options_, `"calendar"`, `"string"`, *undefined*, *undefined*).
         1. Set _opt_.[[ca]] to _calendar_.
-        1. Let _collation_ be ? Get(_options_, `"collation"`).
-        1. If _collation_ is not *undefined*, set _collation_ to ? ToString(_collation_).
+        1. Let _collation_ be ? GetOption(_options_, `"collation"`, `"string"`, *undefined*, *undefined*).
         1. Set _opt_.[[co]] to _collation_.
         1. Let _hc_ be ? GetOption(_options_, `"hourCycle"`, `"string"`, &laquo; `"h11"`, `"h12"`, `"h23"`, `"h24"` &raquo;, *undefined*).
         1. Set _opt_.[[hc]] to _hc_.
@@ -189,8 +184,7 @@ contributors: Mozilla, Ecma International
         1. Let _kn_ be ? GetOption(_options_, `"numeric"`, `"boolean"`, *undefined*, *undefined*).
         1. If _kn_ is not *undefined*, set _kn_ to ! ToString(_kn_).
         1. Set _opt_.[[kn]] to _kn_.
-        1. Let _numberingSystem_ be ? Get(_options_, `"numberingSystem"`).
-        1. If _numberingSystem_ is not *undefined*, set _numberingSystem_ to ? ToString(_numeringSystem_).
+        1. Let _numberingSystem_ be ? GetOption(_options_, `"numberingSystem"`, `"string"`, *undefined*, *undefined*).
         1. Set _opt_.[[nu]] to _numeringSystem_.
         1. Let _localeData_ be %Locale%.[[LocaleData]].
         1. Let _r_ be ResolveLocale( %Locale%.[[AvailableLocales]], _requestedLocales_, _opt_, %Locale%.[[RelevantExtensionKeys]], _localeData_).

--- a/spec.html
+++ b/spec.html
@@ -140,7 +140,11 @@ contributors: Mozilla, Ecma International
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. Let _locale_ be ? OrdinaryCreateFromConstructor(NewTarget, *%LocalePrototype%*, &laquo; [[InitializedLocale]], [[Locale]], [[Calendar]], [[Collation]], [[HourCycle]], [[CaseFirst]], [[Numeric]], [[NumberingSystem]] &raquo;).
-        1. Let _tag_ be ? ToString(_tag_).
+        1. If Type(_tag_) is not String or Object, throw a *TypeError* exception.
+        1. If Type(_tag_) is Object and _tag_ has an [[InitializedLocale]] internal slot, then
+          1. Let _tag_ be _tag_.[[Locale]].
+        1. Else,
+          1. Let _tag_ be ? ToString(_tag_).
         1. If _options_ is *undefined*, then
           1. Let _options_ be ! ObjectCreate(*null*).
         1. Else

--- a/spec.html
+++ b/spec.html
@@ -139,7 +139,13 @@ contributors: Mozilla, Ecma International
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _locale_ be ? OrdinaryCreateFromConstructor(NewTarget, *%LocalePrototype%*, &laquo; [[InitializedLocale]], [[Locale]], [[Calendar]], [[Collation]], [[HourCycle]], [[CaseFirst]], [[Numeric]], [[NumberingSystem]] &raquo;).
+        1. Let _relevantExtensionKeys_ be %Locale%.[[RelevantExtensionKeys]].
+        1. Let _internalSlotsList_ be &laquo; [[InitializedLocale]], [[Locale]], [[Calendar]], [[Collation]], [[HourCycle]], [[NumberingSystem]] &raquo;.
+        1. If _relevantExtensionKeys_ contains `"kf"`, then
+          1. Append [[CaseFirst]] as the last element of _internalSlotsList_.
+        1. If _relevantExtensionKeys_ contains `"kn"`, then
+          1. Append [[Numeric]] as the last element of _internalSlotsList_.
+        1. Let _locale_ be ? OrdinaryCreateFromConstructor(NewTarget, *%LocalePrototype%*, _internalSlotsList_).
         1. If Type(_tag_) is not String or Object, throw a *TypeError* exception.
         1. If Type(_tag_) is Object and _tag_ has an [[InitializedLocale]] internal slot, then
           1. Let _tag_ be _tag_.[[Locale]].
@@ -164,13 +170,15 @@ contributors: Mozilla, Ecma International
         1. Set _opt_.[[kn]] to _kn_.
         1. Let _numberingSystem_ be ? GetOption(_options_, `"numberingSystem"`, `"string"`, *undefined*, *undefined*).
         1. Set _opt_.[[nu]] to _numeringSystem_.
-        1. Let _r_ be ! ApplyUnicodeExtensionToTag(_tag_, _opt_, %Locale%.[[RelevantExtensionKeys]]).
+        1. Let _r_ be ! ApplyUnicodeExtensionToTag(_tag_, _opt_, _relevantExtensionKeys_).
         1. Set _locale_.[[Locale]] to _r_.[[locale]].
         1. Set _locale_.[[Calendar]] to _r_.[[ca]].
         1. Set _locale_.[[Collation]] to _r_.[[co]].
         1. Set _locale_.[[HourCycle]] to _r_.[[hc]].
-        1. Set _locale_.[[CaseFirst]] to _r_.[[kf]].
-        1. Set _locale_.[[Numeric]] to _r_.[[kn]].
+        1. If _relevantExtensionKeys_ contains `"kf"`, then
+          1. Set _locale_.[[CaseFirst]] to _r_.[[kf]].
+        1. If _relevantExtensionKeys_ contains `"kn"`, then
+          1. Set _locale_.[[Numeric]] to _r_.[[kn]].
         1. Set _locale_.[[NumberingSystem]] to _r_.[[nu]].
         1. Set _locale_.[[InitializedLocale]] to *true*.
         1. Return _locale_.
@@ -200,7 +208,7 @@ contributors: Mozilla, Ecma International
       <h1>Internal slots</h1>
 
       <p>
-        The value of the [[RelevantExtensionKeys]] internal slot is &laquo; `"ca"`, `"co"`, `"hc"`, `"kf"`, `"kn"`, `"nu"` &raquo;.
+        The value of the [[RelevantExtensionKeys]] internal slot is &laquo; `"ca"`, `"co"`, `"hc"`, `"kf"`, `"kn"`, `"nu"` &raquo;. If %Collator%.[[RelevantExtensionKeys]] does not contain `"kf"`, then remove `"kf"` from %Locale%.[[RelevantExtensionKeys]]. If %Collator%.[[RelevantExtensionKeys]] does not contain `"kn"`, then remove `"kn"` from %Locale%.[[RelevantExtensionKeys]].
       </p>
     </emu-clause>
   </emu-clause>
@@ -278,7 +286,7 @@ contributors: Mozilla, Ecma International
 
     <emu-clause id="sec-Intl.Locale.prototype.caseFirst">
       <h1>get Intl.Locale.prototype.caseFirst</h1>
-      <p>This property only exists if %Collator%.[[RelevantExtensionKeys]] contains `"kf"`.</p>
+      <p>This property only exists if %Locale%.[[RelevantExtensionKeys]] contains `"kf"`.</p>
       <p>`Intl.Locale.prototype.caseFirst` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.

--- a/spec.html
+++ b/spec.html
@@ -12,52 +12,8 @@ contributors: Mozilla, Ecma International
     <h1>The Intl.Locale Constructor</h1>
 
     <p>
-      The Locale constructor is a standard built-in property of the Intl object. Behaviour common to all service constructor properties of the Intl object is specified in <emu-xref href="#sec-internal-slots"></emu-xref>.
+      The Locale constructor is a standard built-in property of the Intl object.
     </p>
-
-    <emu-table id="table-locale-options">
-      <emu-caption>Supported options</emu-caption>
-      <table class="real-table">
-        <thead>
-          <tr>
-            <td>Option</td>
-            <td>Extension key</td>
-            <td>Internal slot</td>
-          </tr>
-        </thead>
-        <tr>
-          <td>calendar</td>
-          <td>ca</td>
-          <td>[[Calendar]]</td>
-        </tr>
-        <tr>
-          <td>collation</td>
-          <td>co</td>
-          <td>[[Collation]]</td>
-        </tr>
-        <tr>
-          <td>hourCycle</td>
-          <td>hc</td>
-          <td>[[HourCycle]]</td>
-        </tr>
-        <tr>
-          <td>caseFirst</td>
-          <td>kf</td>
-          <td>[[CaseFirst]]</td>
-        </tr>
-        <tr>
-          <td>numeric</td>
-          <td>kn</td>
-          <td>[[Numeric]]</td>
-        </tr>
-        <tr>
-          <td>numberingSystem</td>
-          <td>nu</td>
-          <td>[[NumberingSystem]]</td>
-        </tr>
-      </table>
-    </emu-table>
-
 
     <emu-clause id="sec-apply-options-to-tag" aoid=ApplyOptionsToTag>
       <h1>ApplyOptionsToTag( _tag_, _options_ )</h1>
@@ -91,66 +47,86 @@ contributors: Mozilla, Ecma International
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-findextension" aoid="FindExtension">
-      <h1>FindExtension ( _extension_, _key_ )</h1>
-
-      <p>The abstract operation FindExtension is called with _extension_, which must be a Unicode locale extension sequence, and String _key_. This operation returns start and end indices for the type subtags for _key_ by performing the following steps:</p>
+    <emu-clause id="sec-apply-unicode-extension-to-tag" aoid=ApplyUnicodeExtensionToTag>
+      <h1>ApplyUnicodeExtensionToTag( _tag_, _options_, _relevantExtensionKeys_ )</h1>
+      <p>
+        The following algorithm refers to <a href="https://tools.ietf.org/html/rfc5646#section-2.1">RFC 5646's Language-Tag grammar</a>.
+      </p>
 
       <emu-alg>
-        1. Assert: The number of elements in _key_ is 2.
+        1. Assert: Type(_tag_) is String.
+        1. If _tag_ does not match the `langtag` production, then
+          1. Let _result_ be a new Record.
+          1. Repeat for each element _key_ of _relevantExtensionKeys_ in List order,
+            1. Set result.[[<_key_>]] to *undefined*.
+          1. Set _result_.[[locale]] to _tag_.
+          1. Return _result_.
+        1. If _tag_ contains a substring that is a Unicode locale extension sequence, then
+          1. Let _extension_ be the String value consisting of the first substring of _tag_ that is a Unicode locale extension sequence.
+        1. Else,
+          1. Let _extension_ be the empty String.
+        1. Let _keywords_ be the empty List.
         1. Let _size_ be the number of elements in _extension_.
-        1. Let _searchValue_ be the concatenation of `"-"`, _key_, and `"-"`.
-        1. Let _pos_ be Call(%StringProto_indexOf%, _extension_, &laquo; _searchValue_ &raquo;).
-        1. If _pos_ ≠ -1, then
-          1. Let _start_ be _pos_ + 4.
-          1. Let _end_ be _start_.
-          1. Let _k_ be _start_.
-          1. Let _done_ be *false*.
-          1. Repeat, while _done_ is *false*
-            1. Let _e_ be Call(%StringProto_indexOf%, _extension_, &laquo; `"-"`, _k_ &raquo;).
-            1. If _e_ = -1, let _len_ be _size_ - _k_; else let _len_ be _e_ - _k_.
-            1. If _len_ = 2, then
-              1. Let _done_ be *true*.
-            1. Else if _e_ = -1, then
-              1. Let _end_ be _size_.
-              1. Let _done_ be *true*.
-            1. Else,
-              1. Let _end_ be _e_.
-              1. Let _k_ be _e_ + 1.
-          1. Return a new Record { [[Start]]: _pos_, [[End]]: _end_ }.
-        1. Let _searchValue_ be the concatenation of `"-"` and _key_.
-        1. Let _pos_ be Call(%StringProto_indexOf%, _extension_, &laquo; _searchValue_ &raquo;).
-        1. If _pos_ ≠ -1 and _pos_ + 3 = _size_, then
-          1. Return a new Record { [[Start]]: _pos_, [[End]]: _size_ }.
-        1. Return *undefined*.
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-unicodeextensionvalue" aoid="UnicodeExtensionValue">
-      <h1>UnicodeExtensionValue ( _extension_, _key_ )</h1>
-
-      <p>The abstract operation UnicodeExtensionValue is called with _extension_, which must be a Unicode locale extension sequence, and String _key_. This operation returns the type subtags for _key_ by performing the following steps:</p>
-
-      <emu-alg>
-        1. Let _range_ be FindExtension(_extension_, _key_).
-        1. If _range_ is *undefined*, return *undefined*.
-        1. If _range_.[[Start]] + 4 &ge; _range_.[[End]], return an empty String.
-        1. Otherwise, return a String value equal to the substring of _extension_ from _range_.[[Start]] + 4 (inclusive) to _range_.[[End]] (exclusive).
-      </emu-alg>
-    </emu-clause>
-
-    <emu-clause id="sec-unused-extensions" aoid="UnusedExtensions">
-      <h1>UnusedExtensions ( _r_ )</h1>
-      <emu-alg>
-        1. Let _extension_ be _r_.[[extension]].
-        1. For _key_ in %Locale%.[[RelevantExtensionKeys]],
-          1. Let _done_ be *false*.
-          1. Repeat, while _done_ is *false*,
-            1. Let _range_ be FindExtension(_extension_, _key_).
-            1. If _range_ is *undefined*, set _done_ to *true*.
-            1. Otherwise, set _extension_ to the concatenation of the substring of _extension_ from the beginning to _range_.[[Start]] with the substring of _extension_ from _range_.[[End]] to the end of the string.
-        1. If _extension_ begins with `"-u-"`, set _extension_ to the substring of _extension_ beginning from its fourth index.
-        1. Return _extension_.
+        1. Let _key_ be `"attributes"`.
+        1. Let _value_ be the empty String.
+        1. Let _k_ be 3.
+        1. Repeat, while _k_ &lt; _size_
+          1. Let _e_ be ! Call(%StringProto_indexOf%, _extension_, « `"-"`, _k_ »).
+          1. If _e_ = -1, let _len_ be _size_ - _k_; else let _len_ be _e_ - _k_.
+          1. Let _subtag_ the String value equal to the substring of _extension_ consisting of the code units at indices _k_ (inclusive) through _k_ + _len_ (exclusive).
+          1. If _len_ = 2, then
+            1. If _keywords_ does not contain an element whose [[Key]] is the same as _key_, then
+              1. Append the Record{[[Key]]: _key_, [[Value]]: _value_} to _keywords_.
+            1. Let _key_ be _subtag_.
+            1. Let _value_ be the empty String.
+          1. Else,
+            1. If _value_ is not the empty String, then
+              1. Let _value_ be the string-concatenation of _value_ and `"-"`.
+            1. Let _value_ be the string-concatenation of _value_ and _subtag_.
+          1. Let _k_ be _k_ + _len_ + 1.
+        1. If _keywords_ does not contain an element whose [[Key]] is the same as _key_, then
+          1. Append the Record{[[Key]]: _key_, [[Value]]: _value_} to _keywords_.
+        1. Let _result_ be a new Record.
+        1. Let _newExtension_ be `"-u"`.
+        1. Let _entry_ be the element of _keywords_ whose [[Key]] is the same as `"attributes"`.
+        1. If _entry_.[[Value]] is not the empty String, then
+          1. Let _newExtension_ be the string-concatenation of _newExtension_, `"-"`, and _entry_.[[Value]].
+        1. Remove _entry_ from _keywords_.
+        1. Repeat for each element _key_ of _relevantExtensionKeys_ in List order,
+          1. Let _value_ be *undefined*.
+          1. If _keywords_ contains an element whose [[Key]] is the same as _key_, then
+            1. Let _entry_ be the element of _keywords_ whose [[Key]] is the same as _key_.
+            1. Let _value_ be _entry_.[[Value]].
+            1. Remove _entry_ from _keywords_.
+          1. Assert: _options_ has a field [[<_key_>]].
+          1. Let _optionsValue_ be _options_.[[<_key_>]].
+          1. If _optionsValue_ is not *undefined*, then
+            1. Let _value_ be _optionsValue_.
+          1. Set _result_.[[<_key_>]] to _value_.
+          1. If _value_  is not *undefined*, then
+            1. Assert: Type(_value_) is String.
+            1. Let _newExtension_ be the string-concatenation of _newExtension_, `"-"`, and _key_.
+            1. If _value_ is not the empty String, then
+              1. Let _newExtension_ be the string-concatenation of _newExtension_, `"-"`, and _value_.
+        1. Repeat for each element _entry_ of _keywords_ in List order,
+          1. Let _key_ be _entry_.[[Key]].
+          1. Let _value_ be _entry_.[[Value]].
+          1. Let _newExtension_ be the string-concatenation of _newExtension_, `"-"`, and _key_.
+          1. If _value_ is not the empty String, then
+            1. Let _newExtension_ be the string-concatenation of _newExtension_, `"-"`, and _value_.
+        1. Let _locale_ be the String value that is _tag_ with all Unicode locale extension sequences removed.
+        1. If the number of elements in _newExtension_ is greater than 2, then
+          1. Let _privateIndex_ be ! Call(%StringProto_indexOf%, _locale_, &laquo; `"-x-"` &raquo;).
+          1. If _privateIndex_ = -1, then
+            1. Let _locale_ be the concatenation of _locale_ and _newExtension_.
+          1. Else,
+            1. Let _preExtension_ be the substring of _locale_ from position 0, inclusive, to position _privateIndex_, exclusive.
+            1. Let _postExtension_ be the substring of _locale_ from position _privateIndex_ to the end of the string.
+            1. Let _locale_ be the string-concatenation of _preExtension_, _newExtension_, and _postExtension_.
+          1. Assert: ! IsStructurallyValidLanguageTag(_locale_) is *true*.
+          1. Let _locale_ be ! CanonicalizeLanguageTag(_locale_).
+        1. Set _result_.[[locale]] to _locale_.
+        1. Return _result_.
       </emu-alg>
     </emu-clause>
 
@@ -163,16 +139,14 @@ contributors: Mozilla, Ecma International
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. Let _locale_ be ? OrdinaryCreateFromConstructor(NewTarget, *%LocalePrototype%*, &laquo; [[InitializedLocale]], [[Locale]], [[Calendar]], [[Collation]], [[HourCycle]], [[CaseFirst]], [[Numeric]], [[NumberingSystem]], [[OtherExtensions]] &raquo;).
+        1. Let _locale_ be ? OrdinaryCreateFromConstructor(NewTarget, *%LocalePrototype%*, &laquo; [[InitializedLocale]], [[Locale]], [[Calendar]], [[Collation]], [[HourCycle]], [[CaseFirst]], [[Numeric]], [[NumberingSystem]] &raquo;).
         1. Let _tag_ be ? ToString(_tag_).
         1. If _options_ is *undefined*, then
           1. Let _options_ be ! ObjectCreate(*null*).
         1. Else
           1. Let _options_ be ? ToObject(_options_).
         1. Set _tag_ to ? ApplyOptionsToTag(_tag_, _options_).
-        1. Let _requestedLocales_ be ? CreateArrayFromList(&laquo; _tag_ &raquo;).
         1. Let _opt_ be a new Record.
-        1. Set _opt_.[[localeMatcher]] to `"best fit"`.
         1. Let _calendar_ be ? GetOption(_options_, `"calendar"`, `"string"`, *undefined*, *undefined*).
         1. Set _opt_.[[ca]] to _calendar_.
         1. Let _collation_ be ? GetOption(_options_, `"collation"`, `"string"`, *undefined*, *undefined*).
@@ -186,8 +160,7 @@ contributors: Mozilla, Ecma International
         1. Set _opt_.[[kn]] to _kn_.
         1. Let _numberingSystem_ be ? GetOption(_options_, `"numberingSystem"`, `"string"`, *undefined*, *undefined*).
         1. Set _opt_.[[nu]] to _numeringSystem_.
-        1. Let _localeData_ be %Locale%.[[LocaleData]].
-        1. Let _r_ be ResolveLocale( %Locale%.[[AvailableLocales]], _requestedLocales_, _opt_, %Locale%.[[RelevantExtensionKeys]], _localeData_).
+        1. Let _r_ be ! ApplyUnicodeExtensionToTag(_tag_, _opt_, %Locale%.[[RelevantExtensionKeys]]).
         1. Set _locale_.[[Locale]] to _r_.[[locale]].
         1. Set _locale_.[[Calendar]] to _r_.[[ca]].
         1. Set _locale_.[[Collation]] to _r_.[[co]].
@@ -195,7 +168,6 @@ contributors: Mozilla, Ecma International
         1. Set _locale_.[[CaseFirst]] to _r_.[[kf]].
         1. Set _locale_.[[Numeric]] to _r_.[[kn]].
         1. Set _locale_.[[NumberingSystem]] to _r_.[[nu]].
-        1. Set _locale_.[[OtherExtensions]] to UnusedExtensions(_r_).
         1. Set _locale_.[[InitializedLocale]] to *true*.
         1. Return _locale_.
       </emu-alg>
@@ -224,39 +196,8 @@ contributors: Mozilla, Ecma International
       <h1>Internal slots</h1>
 
       <p>
-        The value of the [[AvailableLocales]] internal slot is the List of all two- or three-character strings with code points in the range `"a"` through `"z"`. This will contain at least the union of %DateTimeFormat%.[[AvailableLocales]], %NumberFormat%.[[AvailableLocales]] and %Collator%.[[AvailableLocales]].
-      </p>
-
-      <p>
         The value of the [[RelevantExtensionKeys]] internal slot is &laquo; `"ca"`, `"co"`, `"hc"`, `"kf"`, `"kn"`, `"nu"` &raquo;.
-        %Collator%.[[RelevantExtensionKeys]] contains `"kf"`, then %Locale%.[[RelevantExtensionKeys]] includes `"kf"`.
-        %Collator%.[[RelevantExtensionKeys]] contains `"kn"`, then %Locale%.[[RelevantExtensionKeys]] includes `"kn"`.
       </p>
-
-      <p>
-        The value of the [[LocaleData]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref> and the following additional constraints:
-      </p>
-
-      <ul>
-        <li>
-          For each supported locale _locale_, %Locale%.[[LocaleData]][[&lt;_locale_&gt;]].[[ca]] contains %DateTimeFormat%.[[LocaleData]][[&lt;_locale_&gt;]].[[ca]]
-        </li>
-        <li>
-          For each supported locale _locale_, %Locale%.[[LocaleData]][[&lt;_locale_&gt;]].[[co]] contains %Collator%.[[LocaleData]][[&lt;_locale_&gt;]].[[co]]
-        </li>
-        <li>
-          [[LocaleData]][[&lt;_locale_&gt;]].[[hc]] must be &laquo; *null*, `"h11"`, `"h12"`, `"h23"`, `"h24"` &raquo; for all locale values.
-        </li>
-        <li>
-          For each supported locale _locale_, %Locale%.[[LocaleData]][[&lt;_locale_&gt;]].[[kf]] contains %Collator%.[[LocaleData]][[&lt;_locale_&gt;]].[[kf]]
-        </li>
-        <li>
-          For each supported locale _locale_, %Locale%.[[LocaleData]][[&lt;_locale_&gt;]].[[kn]] contains %Collator%.[[LocaleData]][[&lt;_locale_&gt;]].[[kn]]
-        </li>
-        <li>
-          For each supported locale _locale_, %Locale%.[[LocaleData]][[&lt;_locale_&gt;]].[[nu]] contains %DateTimeFormat%.[[LocaleData]][[&lt;_locale_&gt;]].[[nu]]
-        </li>
-      </ul>
     </emu-clause>
   </emu-clause>
 
@@ -287,30 +228,6 @@ contributors: Mozilla, Ecma International
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-locale-to-string" aoid=LocaleToString>
-      <h1>LocaleToString ( _loc_ )</h1>
-
-      <emu-alg>
-      1. Assert: _loc_ has an [[InitializedLocale]] internal slot.
-      1. Let _locale_ be _loc_.[[Locale]].
-      1. Let _extension_ be an empty String.
-      1. For each row in <emu-xref href="#table-locale-options"></emu-xref>, except the header row, in table order, do:
-        1. Let _key_ be the extension key given in the Extension key column of the row.
-        1. Let _slot_ be the Internal Slot column of the row.
-        1. Let _value_ be _locale_.[[&lt;_slot_&gt;]].
-        1. If _value_ is not *undefined*,
-          1. Let _kvp_ be a String value produced by concatenating `"-"`, _key_, `"-"`, and ! ToString(_value_).
-          1. Set _extension_ to a String value produced by concatenating _extension_ and _kvp_.
-      1. Set _extension_ to a String value produced by concatenating _extension_ and _loc_.[[OtherExtensions]].
-      1. If _extension_ is not empty, then,
-        1. If _extension_ does not have `"-"` as its third character, let _extension_ be the concatenation of `"-u"` and _extension_.
-        1. Let _result_ be a String value produced by concatenating _locale_ and _extension_.
-        1. Return _result_.
-      1. Else,
-        1. Return _locale_.
-      </emu-alg>
-    </emu-clause>
-
     <emu-clause id="sec-Intl.Locale.prototype.toString">
       <h1>Intl.Locale.prototype.toString ()</h1>
 
@@ -318,7 +235,7 @@ contributors: Mozilla, Ecma International
       1. Let _loc_ be the *this* value.
       1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
         1. Throw a *TypeError* exception.
-      1. Return LocaleToString(_loc_).
+      1. Return _loc_.[[Locale]].
       </emu-alg>
     </emu-clause>
 
@@ -460,7 +377,7 @@ contributors: Mozilla, Ecma International
             1. Let _kValue_ be ? Get(_O_, _Pk_).
             1. If Type(_kValue_) is not String or Object, throw a *TypeError* exception.
             1. <ins>If Type(_kValue_) is Object and _kValue_ has an [[InitializedLocale]] internal slot, then</ins>
-              1. <ins>Let _tag_ be LocaleToString(_kValue_).</ins>
+              1. <ins>Let _tag_ be _kValue_.[[Locale]].</ins>
             1. <ins>Else,</ins>
               1. Let _tag_ be ? ToString(_kValue_).
             1. If IsStructurallyValidLanguageTag(_tag_) is *false*, throw a *RangeError* exception.

--- a/spec.html
+++ b/spec.html
@@ -60,36 +60,36 @@ contributors: Mozilla, Ecma International
 
 
     <emu-clause id="sec-apply-options-to-tag" aoid=ApplyOptionsToTag>
-      <h1>ApplyOptionsToTag( tag, options )</h1>
+      <h1>ApplyOptionsToTag( _tag_, _options_ )</h1>
       <p>
         The following algorithm refers to <a href="https://tools.ietf.org/html/rfc5646#section-2.1">RFC 5646's Language-Tag grammar</a>.
       </p>
 
       <emu-alg>
-        1. Set _tag_ to ? ToString(_tag_).
+        1. Assert: Type(_tag_) is String.
         1. If IsStructurallyValidLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
-        1. If _tag_ matches the `langtag` production,
+        1. If _tag_ matches the `langtag` production, then
           1. Let _language_ be ? Get(_options_, `"language"`).
-          1. If _language_ is not *undefined*,
+          1. If _language_ is not *undefined*, then
             1. Set _language_ to ? ToString(_language_).
             1. If _language_ does not match the `language` production, throw a *RangeError* exception.
             1. Set _tag_ to _tag_ with the substring corresponding to the `language` production replaced by the string _language_.
           1. Let _script_ be ? Get(_options_, `"script"`).
-          1. If _script_ is not *undefined*,
+          1. If _script_ is not *undefined*, then
             1. Set _script_ to ? ToString(_script_).
             1. If _script_ does not match the `script` production, throw a *RangeError* exception.
-            1. If _tag_ does not contain a `script` production,
+            1. If _tag_ does not contain a `script` production, then
               1. Set _tag_ to the concatenation of the `language` production of _tag_, `"-"`, _script_, and the rest of _tag_.
             1. Else,
-              1. Set _tag_ to _tag_ with the substring corresponding to the `region` production replaced by the string _language_.
+              1. Set _tag_ to _tag_ with the substring corresponding to the `script` production replaced by the string _script_.
           1. Let _region_ be ? Get(_options_, `"region"`).
-          1. If _region_ is not *undefined*,
+          1. If _region_ is not *undefined*, then
             1. Set _region_ to ? ToString(_region_).
             1. If _region_ does not match the `region` production, throw a *RangeError* exception.
-            1. If _tag_ does not contain a `region` production,
-              1. Set _tag_ to the concatenation of the `language` production of _tag_, the substring corresponding to the `"-" script` production if present, `"-"`, _script_, and the rest of _tag_.
+            1. If _tag_ does not contain a `region` production, then
+              1. Set _tag_ to the concatenation of the `language` production of _tag_, the substring corresponding to the `"-" script` production if present, `"-"`, _region_, and the rest of _tag_.
             1. Else,
-              1. Set _tag_ to _tag_ with the substring corresponding to the `region` production replaced by the string _language_.
+              1. Set _tag_ to _tag_ with the substring corresponding to the `region` production replaced by the string _region_.
         1. Return CanonicalizeLanguageTag(_tag_).
       </emu-alg>
     </emu-clause>
@@ -143,7 +143,7 @@ contributors: Mozilla, Ecma International
     </emu-clause>
 
     <emu-clause id="sec-unused-extensions" aoid="UnusedExtensions">
-      <h1>UnusedExtensions ( r )</h1>
+      <h1>UnusedExtensions ( _r_ )</h1>
       <emu-alg>
         1. Let _extension_ be _r_.[[extension]].
         1. For _key_ in %Locale%.[[RelevantExtensionKeys]],
@@ -158,7 +158,7 @@ contributors: Mozilla, Ecma International
     </emu-clause>
 
     <emu-clause id="sec-Intl.Locale">
-      <h1>Intl.Locale( tag[, options] )</h1>
+      <h1>Intl.Locale( _tag_ [, _options_] )</h1>
 
       <p>
         When the *Intl.Locale* function is called with an argument _tag_ and an optional argument _options_, the following steps are taken:
@@ -167,12 +167,14 @@ contributors: Mozilla, Ecma International
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. Let _locale_ be ? OrdinaryCreateFromConstructor(NewTarget, *%LocalePrototype%*, &laquo; [[InitializedLocale]], [[Locale]], [[Calendar]], [[Collation]], [[HourCycle]], [[CaseFirst]], [[Numeric]], [[NumberingSystem]], [[OtherExtensions]] &raquo;).
-        1. Set _tag_ to ApplyOptionsToTag(_tag_).
-        1. Let _requestedLocales_ be ? CreateArrayFromList(&laquo; _tag_ &raquo;).
+        1. Let _tag_ be ? ToString(_tag_).
         1. If _options_ is *undefined*, then
-          1. Let _options_ be ObjectCreate(*null*).
+          1. Let _options_ be ! ObjectCreate(*null*).
         1. Else
           1. Let _options_ be ? ToObject(_options_).
+        1. Set _tag_ to ? ApplyOptionsToTag(_tag_, _options_).
+        1. Let _requestedLocales_ be ? CreateArrayFromList(&laquo; _tag_ &raquo;).
+        1. Let _opt_ be a new Record.
         1. Set _opt_.[[localeMatcher]] to `"best fit"`.
         1. Let _calendar_ be ? Get(_options_, `"calendar"`).
         1. If _calendar_ is not *undefined*, set _calendar_ to ? ToString(_calendar_).
@@ -185,7 +187,7 @@ contributors: Mozilla, Ecma International
         1. Let _kf_ be ? GetOption(_options_, `"caseFirst"`, `"string"`, &laquo; `"upper"`, `"lower"`, `"false"` &raquo;, *undefined*).
         1. Set _opt_.[[kf]] to _kf_.
         1. Let _kn_ be ? GetOption(_options_, `"numeric"`, `"boolean"`, *undefined*, *undefined*).
-        1. If _kn_ is not *undefined*, set _kn_ to ? ToString(_kn_).
+        1. If _kn_ is not *undefined*, set _kn_ to ! ToString(_kn_).
         1. Set _opt_.[[kn]] to _kn_.
         1. Let _numberingSystem_ be ? Get(_options_, `"numberingSystem"`).
         1. If _numberingSystem_ is not *undefined*, set _numberingSystem_ to ? ToString(_numeringSystem_).
@@ -268,10 +270,7 @@ contributors: Mozilla, Ecma International
     <h1>Properties of the Intl.Locale Prototype Object</h1>
 
     <p>
-      The Intl.Locale prototype object is itself an Intl.Locale instance as specified in <emu-xref href="#sec-properties-of-intl-locale-instances"></emu-xref>, whose internal slots are set as if it had been constructed by the expression Construct(*%Locale%*).
-    </p>
-    <p>
-      In the following descriptions of functions that are properties or [[Get]] attributes of properties of *%LocalePrototype%*, the phrase "this Locale object" refers to the object that is the this  value for the invocation of the function; a *TypeError* exception is thrown if the this value is not an object or an object.
+      The Intl.Locale prototype object is itself an ordinary object. %LocalePrototype% is not an Intl.Locale instance and does not have an [[InitializedLocale]] internal slot or any of the other internal slots of Intl.Locale instance objects.
     </p>
 
     <emu-clause id="sec-Intl.Locale.prototype.constructor">
@@ -295,14 +294,14 @@ contributors: Mozilla, Ecma International
     </emu-clause>
 
     <emu-clause id="sec-locale-to-string" aoid=LocaleToString>
-      <h1>LocaleToString ( loc )</h1>
+      <h1>LocaleToString ( _loc_ )</h1>
 
       <emu-alg>
       1. Assert: _loc_ has an [[InitializedLocale]] internal slot.
       1. Let _locale_ be _loc_.[[Locale]].
       1. Let _extension_ be an empty String.
       1. For each row in <emu-xref href="#table-locale-options"></emu-xref>, except the header row, in table order, do:
-        1. Let _name_ be the name given in the Option column of the row.
+        1. Let _key_ be the extension key given in the Extension key column of the row.
         1. Let _slot_ be the Internal Slot column of the row.
         1. Let _value_ be _locale_.[[&lt;_slot_&gt;]].
         1. If _value_ is not *undefined*,
@@ -323,7 +322,8 @@ contributors: Mozilla, Ecma International
 
       <emu-alg>
       1. Let _loc_ be the *this* value.
-      1. If Type(_loc_) is not Object, or _loc_ does not have an [[InitializedLocale]] internal slot, throw a *TypeError* exception.
+      1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
+        1. Throw a *TypeError* exception.
       1. Return LocaleToString(_loc_).
       </emu-alg>
     </emu-clause>
@@ -333,7 +333,8 @@ contributors: Mozilla, Ecma International
       <p>`Intl.Locale.prototype.calendar` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
-        1. If Type(_loc_) does not have an [[InitializedLocale]] internal slot, throw a *TypeError* exception.
+        1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
+          1. Throw a *TypeError* exception.
         1. Return _loc_.[[Calendar]].
       </emu-alg>
     </emu-clause>
@@ -343,7 +344,8 @@ contributors: Mozilla, Ecma International
       <p>`Intl.Locale.prototype.collation` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
-        1. If Type(_loc_) does not have an [[InitializedLocale]] internal slot, throw a *TypeError* exception.
+        1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
+          1. Throw a *TypeError* exception.
         1. Return _loc_.[[Collation]].
       </emu-alg>
     </emu-clause>
@@ -353,7 +355,8 @@ contributors: Mozilla, Ecma International
       <p>`Intl.Locale.prototype.hourCycle` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
-        1. If Type(_loc_) does not have an [[InitializedLocale]] internal slot, throw a *TypeError* exception.
+        1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
+          1. Throw a *TypeError* exception.
         1. Return _loc_.[[HourCycle]].
       </emu-alg>
     </emu-clause>
@@ -364,7 +367,8 @@ contributors: Mozilla, Ecma International
       <p>`Intl.Locale.prototype.caseFirst` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
-        1. If Type(_loc_) does not have an [[InitializedLocale]] internal slot, throw a *TypeError* exception.
+        1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
+          1. Throw a *TypeError* exception.
         1. Return _loc_.[[CaseFirst]].
       </emu-alg>
     </emu-clause>
@@ -375,7 +379,8 @@ contributors: Mozilla, Ecma International
       <p>`Intl.Locale.prototype.numeric` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
-        1. If Type(_loc_) does not have an [[InitializedLocale]] internal slot, throw a *TypeError* exception.
+        1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
+          1. Throw a *TypeError* exception.
         1. Return _loc_.[[Numeric]].
       </emu-alg>
     </emu-clause>
@@ -385,7 +390,8 @@ contributors: Mozilla, Ecma International
       <p>`Intl.Locale.prototype.numberingSystem` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
-        1. If Type(_loc_) does not have an [[InitializedLocale]] internal slot, throw a *TypeError* exception.
+        1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
+          1. Throw a *TypeError* exception.
         1. Return _loc_.[[NumberingSystem]].
       </emu-alg>
     </emu-clause>
@@ -395,7 +401,8 @@ contributors: Mozilla, Ecma International
       <p>`Intl.Locale.prototype.language` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="https://tools.ietf.org/html/rfc5646#section-2.1">RFC 5646's Language-Tag grammar</a>. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
-        1. If Type(_loc_) does not have an [[InitializedLocale]] internal slot, throw a *TypeError* exception.
+        1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
+          1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
         1. If _locale_ does not match the `langtag` production, return *undefined*.
         1. Return the substring of _locale_ corresponding to the `language` production.
@@ -407,10 +414,11 @@ contributors: Mozilla, Ecma International
       <p>`Intl.Locale.prototype.script` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="https://tools.ietf.org/html/rfc5646#section-2.1">RFC 5646's Language-Tag grammar</a>. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
-        1. If Type(_loc_) does not have an [[InitializedLocale]] internal slot, throw a *TypeError* exception.
+        1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
+          1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
         1. If _locale_ does not match the `langtag` production, return *undefined*.
-        1. If _locale_ contains a no repetitions of the `["-" script]` sequence, return *undefined*.
+        1. If _locale_ does not contain the `["-" script]` sequence, return *undefined*.
         1. Return the substring of _locale_ corresponding to the `script` production.
       </emu-alg>
     </emu-clause>
@@ -420,10 +428,11 @@ contributors: Mozilla, Ecma International
       <p>`Intl.Locale.prototype.region` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="https://tools.ietf.org/html/rfc5646#section-2.1">RFC 5646's Language-Tag grammar</a>. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
-        1. If Type(_loc_) does not have an [[InitializedLocale]] internal slot, throw a *TypeError* exception.
+        1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
+          1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
         1. If _locale_ does not match the `langtag` production, return *undefined*.
-        1. If _locale_ contains a no repetitions of the `["-" region]` sequence, return *undefined*.
+        1. If _locale_ does not contain the `["-" region]` sequence, return *undefined*.
         1. Return the substring of _locale_ corresponding to the `region` production.
       </emu-alg>
     </emu-clause>
@@ -456,9 +465,9 @@ contributors: Mozilla, Ecma International
           1. If _kPresent_ is *true*, then
             1. Let _kValue_ be ? Get(_O_, _Pk_).
             1. If Type(_kValue_) is not String or Object, throw a *TypeError* exception.
-            1. <ins>If Type(_kValue_) is Object and _kValue_ has an [[InitializedLocale]] internal slot,</ins>
+            1. <ins>If Type(_kValue_) is Object and _kValue_ has an [[InitializedLocale]] internal slot, then</ins>
               1. <ins>Let _tag_ be LocaleToString(_kValue_).</ins>
-            1. <ins>Otherwise,</ins>
+            1. <ins>Else,</ins>
               1. Let _tag_ be ? ToString(_kValue_).
             1. If IsStructurallyValidLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
             1. Let _canonicalizedTag_ be CanonicalizeLanguageTag(_tag_).


### PR DESCRIPTION
I've tried to implement the `Intl.Locale` proposal at https://bugzilla.mozilla.org/show_bug.cgi?id=1433303, but some parts of the current spec seem to incomplete/buggy, so here's a stab at fixing some of the issues I've found. 

637d9c90b9bc5b5424cca728eeec6e8a4665f7ca
General fixes (missing "then", typos, etc.)

aedbbbcc5e7c223644115c9edac61d02de06c795
Adds calls to `GetOption`, so we don't need to perform manual type conversions in some places. (Basically to follow the in-house style of ECMA-402 😄 )

dd9f44b6632cf74081dbafa592617f4ac928b49b
The current approach doesn't quite work some edge-cases (attributes in Unicode extension sequences, private-use subtags, irregular grandfathered language tags, etc.). And `ResolveLocale` doesn't really fit for `Intl.Locale`, does it? For example I assume `new Intl.Locale("en", {nu: "latn"})` should return `"en-u-nu-latn"`, right? (Using `ResolveLocale` it'd return `"en"`, because extension keys supplied as options remove extension keys from the Unicode extension sequence.)

a222fb3b2674031d280d0b00e819b6ce60063fea
Restricts the `tag` parameter for `Intl.Locale` to strings and objects, and also directly accesses [[Locale]] for `Intl.Locale` objects. Using normal ToString conversion doesn't really make sense for language tags (see [this test case](https://bugzilla.mozilla.org/attachment.cgi?id=8948428&action=diff#a/js/src/tests/non262/Intl/Locale/locale-constructor-tostring-conversion.js_sec1)) and I think it makes sense to align `Intl.Locale` with `CanonicalizeLocaleList `.

48e47b7efbdaa2752617e1529a7a975c47f8fd63
Restores (was partially removed in dd9f44b6632cf74081dbafa592617f4ac928b49b) and fixes some bugs  (undefined record fields were accessed) in the optional support for kf and kn. (TBH I'm not really sure we want to copy the `Intl.Collator` restriction over to `Intl.Locale`, but this should be decided in a different issue.)