### PR TITLE
Canonicalize Unicode extensions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -63,35 +63,16 @@ contributors: Mozilla, Ecma International
           1. Return _result_.
         1. If _tag_ contains a substring that is a Unicode locale extension sequence, then
           1. Let _extension_ be the String value consisting of the first substring of _tag_ that is a Unicode locale extension sequence.
+          1. Let _components_ be ! UnicodeExtensionComponents(_extension_).
+          1. Let _attributes_ be _components_.[[Attributes]].
+          1. Let _keywords_ be _components_.[[Keywords]].
         1. Else,
-          1. Let _extension_ be the empty String.
-        1. Let _keywords_ be the empty List.
-        1. Let _size_ be the number of elements in _extension_.
-        1. Let _key_ be `"attributes"`.
-        1. Let _value_ be the empty String.
-        1. Let _k_ be 3.
-        1. Repeat, while _k_ &lt; _size_
-          1. Let _e_ be ! Call(%StringProto_indexOf%, _extension_, « `"-"`, _k_ »).
-          1. If _e_ = -1, let _len_ be _size_ - _k_; else let _len_ be _e_ - _k_.
-          1. Let _subtag_ the String value equal to the substring of _extension_ consisting of the code units at indices _k_ (inclusive) through _k_ + _len_ (exclusive).
-          1. If _len_ = 2, then
-            1. If _keywords_ does not contain an element whose [[Key]] is the same as _key_, then
-              1. Append the Record{[[Key]]: _key_, [[Value]]: _value_} to _keywords_.
-            1. Let _key_ be _subtag_.
-            1. Let _value_ be the empty String.
-          1. Else,
-            1. If _value_ is not the empty String, then
-              1. Let _value_ be the string-concatenation of _value_ and `"-"`.
-            1. Let _value_ be the string-concatenation of _value_ and _subtag_.
-          1. Let _k_ be _k_ + _len_ + 1.
-        1. If _keywords_ does not contain an element whose [[Key]] is the same as _key_, then
-          1. Append the Record{[[Key]]: _key_, [[Value]]: _value_} to _keywords_.
+          1. Let _attributes_ be the empty List.
+          1. Let _keywords_ be the empty List.
         1. Let _result_ be a new Record.
         1. Let _newExtension_ be `"-u"`.
-        1. Let _entry_ be the element of _keywords_ whose [[Key]] is the same as `"attributes"`.
-        1. If _entry_.[[Value]] is not the empty String, then
-          1. Let _newExtension_ be the string-concatenation of _newExtension_, `"-"`, and _entry_.[[Value]].
-        1. Remove _entry_ from _keywords_.
+        1. Repeat for each element _attribute_ of _attributes_ in List order,
+          1. Let _newExtension_ be the string-concatenation of _newExtension_, `"-"`, and _attribute_.
         1. Repeat for each element _key_ of _relevantExtensionKeys_ in List order,
           1. Let _value_ be *undefined*.
           1. If _keywords_ contains an element whose [[Key]] is the same as _key_, then
@@ -119,6 +100,45 @@ contributors: Mozilla, Ecma International
           1. Let _locale_ be ! InsertUnicodeExtension(_locale_, _newExtension_).
         1. Set _result_.[[locale]] to _locale_.
         1. Return _result_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-unicode-extension-components" aoid=UnicodeExtensionComponents>
+      <h1>UnicodeExtensionComponents( _extension_ )</h1>
+      <p>
+        The UnicodeExtensionComponents abstract operation returns the attributes and keywords from _extension_, which must be a Unicode locale extension sequence. If an attribute or a keyword occurs multiple times in _extension_, only the first occurence is returned. The following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Let _attributes_ be the empty List.
+        1. Let _keywords_ be the empty List.
+        1. Let _isKeyword_ be *false*.
+        1. Let _size_ be the number of elements in _extension_.
+        1. Let _k_ be 3.
+        1. Repeat, while _k_ &lt; _size_
+          1. Let _e_ be ! Call(%StringProto_indexOf%, _extension_, « `"-"`, _k_ »).
+          1. If _e_ = -1, let _len_ be _size_ - _k_; else let _len_ be _e_ - _k_.
+          1. Let _subtag_ the String value equal to the substring of _extension_ consisting of the code units at indices _k_ (inclusive) through _k_ + _len_ (exclusive).
+          1. If _isKeyword_ is *false*, then
+            1. If _len_ &ne; 2 and _subtag_ is not an element of _attributes_, then
+              1. Append _subtag_ to _attributes_.
+          1. Else,
+            1. If _len_ = 2, then
+              1. If _keywords_ does not contain an element whose [[Key]] is the same as _key_, then
+                1. Append the Record{[[Key]]: _key_, [[Value]]: _value_} to _keywords_.
+            1. Else,
+              1. If _value_ is not the empty String, then
+                1. Let _value_ be the string-concatenation of _value_ and `"-"`.
+              1. Let _value_ be the string-concatenation of _value_ and _subtag_.
+          1. If _len_ = 2, then
+            1. Let _isKeyword_ be *true*.
+            1. Let _key_ be _subtag_.
+            1. Let _value_ be the empty String.
+          1. Let _k_ be _k_ + _len_ + 1.
+        1. If _isKeyword_ is *true*, then
+          1. If _keywords_ does not contain an element whose [[Key]] is the same as _key_, then
+            1. Append the Record{[[Key]]: _key_, [[Value]]: _value_} to _keywords_.
+        1. Return the Record{[[Attributes]]: _attributes_, [[Keywords]]: _keywords_}.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -70,33 +70,26 @@ contributors: Mozilla, Ecma International
           1. Let _attributes_ be the empty List.
           1. Let _keywords_ be the empty List.
         1. Let _result_ be a new Record.
-        1. Let _newExtension_ be `"-u"`.
-        1. Repeat for each element _attribute_ of _attributes_ in List order,
-          1. Let _newExtension_ be the string-concatenation of _newExtension_, `"-"`, and _attribute_.
         1. Repeat for each element _key_ of _relevantExtensionKeys_ in List order,
           1. Let _value_ be *undefined*.
           1. If _keywords_ contains an element whose [[Key]] is the same as _key_, then
             1. Let _entry_ be the element of _keywords_ whose [[Key]] is the same as _key_.
             1. Let _value_ be _entry_.[[Value]].
-            1. Remove _entry_ from _keywords_.
+          1. Else
+            1. Let _entry_ be ~empty~.
           1. Assert: _options_ has a field [[<_key_>]].
           1. Let _optionsValue_ be _options_.[[<_key_>]].
           1. If _optionsValue_ is not *undefined*, then
+            1. Assert: Type(_optionsValue_) is String.
             1. Let _value_ be _optionsValue_.
+            1. If _entry_ is not ~empty~, then
+              1. Set _entry_.[[Value]] to _value_.
+            1. Else,
+              1. Append the Record{[[Key]]: _key_, [[Value]]: _value_} to _keywords_.
           1. Set _result_.[[<_key_>]] to _value_.
-          1. If _value_  is not *undefined*, then
-            1. Assert: Type(_value_) is String.
-            1. Let _newExtension_ be the string-concatenation of _newExtension_, `"-"`, and _key_.
-            1. If _value_ is not the empty String, then
-              1. Let _newExtension_ be the string-concatenation of _newExtension_, `"-"`, and _value_.
-        1. Repeat for each element _entry_ of _keywords_ in List order,
-          1. Let _key_ be _entry_.[[Key]].
-          1. Let _value_ be _entry_.[[Value]].
-          1. Let _newExtension_ be the string-concatenation of _newExtension_, `"-"`, and _key_.
-          1. If _value_ is not the empty String, then
-            1. Let _newExtension_ be the string-concatenation of _newExtension_, `"-"`, and _value_.
         1. Let _locale_ be the String value that is _tag_ with all Unicode locale extension sequences removed.
-        1. If the number of elements in _newExtension_ is greater than 2, then
+        1. Let _newExtension_ be ! CanonicalizeUnicodeExtension(_attributes_, _keywords_).
+        1. If _newExtension_ is not the empty String, then
           1. Let _locale_ be ! InsertUnicodeExtension(_locale_, _newExtension_).
         1. Set _result_.[[locale]] to _locale_.
         1. Return _result_.
@@ -139,6 +132,32 @@ contributors: Mozilla, Ecma International
           1. If _keywords_ does not contain an element whose [[Key]] is the same as _key_, then
             1. Append the Record{[[Key]]: _key_, [[Value]]: _value_} to _keywords_.
         1. Return the Record{[[Attributes]]: _attributes_, [[Keywords]]: _keywords_}.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-canonicalize-unicode-extension" aoid=CanonicalizeUnicodeExtension>
+      <h1>CanonicalizeUnicodeExtension( _attributes_, _keywords_ )</h1>
+      <p>
+        The CanonicalizeUnicodeExtension abstract operation creates the canonical Unicode locale extension sequence from _attributes_, which must be a List of String values, and _keywords_, which must be a List of Record values. The empty String is returned if both arguments are empty Lists. The following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. If _attributes_ is empty and _keywords_ is empty, then
+          1. Return the empty String.
+        1. Let _sortedAttributes_ be a new List containing the same values as the list _attributes_ where the values are ordered as if an Array of the same values had been sorted using `Array.prototype.sort` using *undefined* as _comparefn_.
+        1. Let _fullKeywords_ be the empty List.
+        1. Repeat for each element _entry_ of _keywords_ in List order,
+          1. Let _keyword_ be _entry_.[[Key]].
+          1. If _entry_.[[Value]] is not the empty String, then
+            1. Let _keyword_ be the string-concatenation of _keyword_, `"-"`, and _entry_.[[Value]].
+          1. Append _keyword_ to _fullKeywords_.
+        1. Let _sortedKeywords_ be a new List containing the same values as the list _fullKeywords_ where the values are ordered as if an Array of the same values had been sorted using `Array.prototype.sort` using *undefined* as _comparefn_.
+        1. Let _extension_ be `"-u"`.
+        1. Repeat for each element _attribute_ of _sortedAttributes_ in List order,
+          1. Let _extension_ be the string-concatenation of _extension_, `"-"`, and _attribute_.
+        1. Repeat for each element _keyword_ of _sortedKeywords_ in List order,
+          1. Let _extension_ be the string-concatenation of _extension_, `"-"`, and _keyword_.
+        1. Return _extension_.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -116,17 +116,30 @@ contributors: Mozilla, Ecma International
             1. Let _newExtension_ be the string-concatenation of _newExtension_, `"-"`, and _value_.
         1. Let _locale_ be the String value that is _tag_ with all Unicode locale extension sequences removed.
         1. If the number of elements in _newExtension_ is greater than 2, then
-          1. Let _privateIndex_ be ! Call(%StringProto_indexOf%, _locale_, &laquo; `"-x-"` &raquo;).
-          1. If _privateIndex_ = -1, then
-            1. Let _locale_ be the concatenation of _locale_ and _newExtension_.
-          1. Else,
-            1. Let _preExtension_ be the substring of _locale_ from position 0, inclusive, to position _privateIndex_, exclusive.
-            1. Let _postExtension_ be the substring of _locale_ from position _privateIndex_ to the end of the string.
-            1. Let _locale_ be the string-concatenation of _preExtension_, _newExtension_, and _postExtension_.
-          1. Assert: ! IsStructurallyValidLanguageTag(_locale_) is *true*.
-          1. Let _locale_ be ! CanonicalizeLanguageTag(_locale_).
+          1. Let _locale_ be ! InsertUnicodeExtension(_locale_, _newExtension_).
         1. Set _result_.[[locale]] to _locale_.
         1. Return _result_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-insert-unicode-extension" aoid=InsertUnicodeExtension>
+      <h1>InsertUnicodeExtension( _locale_, _extension_ )</h1>
+      <p>
+        The InsertUnicodeExtension abstract operation inserts _extension_, which must be a Unicode locale extension sequence, into _locale_, which must be a String value with a structurally valid and canonicalized BCP 47 language tag. The following steps are taken:
+      </p>
+
+      <emu-alg>
+        1. Assert: _locale_ does not contain a substring that is a Unicode locale extension sequence.
+        1. Assert: _extension_ is a Unicode extension sequence.
+        1. Let _privateIndex_ be ! Call(%StringProto_indexOf%, _locale_, &laquo; `"-x-"` &raquo;).
+        1. If _privateIndex_ = -1, then
+          1. Let _locale_ be the concatenation of _locale_ and _extension_.
+        1. Else,
+          1. Let _preExtension_ be the substring of _locale_ from position 0, inclusive, to position _privateIndex_, exclusive.
+          1. Let _postExtension_ be the substring of _locale_ from position _privateIndex_ to the end of the string.
+          1. Let _locale_ be the string-concatenation of _preExtension_, _extension_, and _postExtension_.
+        1. Assert: ! IsStructurallyValidLanguageTag(_locale_) is *true*.
+        1. Return ! CanonicalizeLanguageTag(_locale_).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
03aa810d82713e3f1ecca532351c3a7a428a35f3
- Splits the steps copied from [ResolveLocale](https://tc39.github.io/ecma402/#sec-resolvelocale) into a separate abstract operation to make it easier to reuse them when merge this proposal with the main spec.

c7d45617bb372ae4af008b9c87118408044b01db
- Splits the Unicode extension parsing steps into a separate abstract operation.
- Also keeps the Unicode extension attributes in a separate list and already deduplicates them (similar to keywords, only the first occurrence of an attribute is significant).

adaa439f1bca231fc00be55677866b9c5fa53fbd
- Add finally another new abstract operation to canonicalize the attributes and keywords in a Unicode extension sequence.
- I'm not quite happy about the number of steps required to describe this canonicalization operation in ECMAspeak. Maybe we should just use natural language for this part?


Fixes #14