### PR TITLE
Ensure 'calendar', 'collation', and 'numberingSystem' are valid Unicode extension types

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -189,6 +189,8 @@ contributors: Mozilla, Ecma International
       <h1>Intl.Locale( _tag_ [, _options_] )</h1>
 
       <p>
+        The following algorithm refers to <a href="https://tools.ietf.org/html/rfc5646#section-2.1">RFC 5646's Language-Tag grammar</a>.
+
         When the *Intl.Locale* function is called with an argument _tag_ and an optional argument _options_, the following steps are taken:
       </p>
 
@@ -213,8 +215,12 @@ contributors: Mozilla, Ecma International
         1. Set _tag_ to ? ApplyOptionsToTag(_tag_, _options_).
         1. Let _opt_ be a new Record.
         1. Let _calendar_ be ? GetOption(_options_, `"calendar"`, `"string"`, *undefined*, *undefined*).
+        1. If _calendar_ is not *undefined*, then
+          1. If _calendar_ does not match the `[(3*8alphanum) *("-" (3*8alphanum))]` sequence, throw a *RangeError* exception.
         1. Set _opt_.[[ca]] to _calendar_.
         1. Let _collation_ be ? GetOption(_options_, `"collation"`, `"string"`, *undefined*, *undefined*).
+        1. If _collation_ is not *undefined*, then
+          1. If _collation_ does not match the `[(3*8alphanum) *("-" (3*8alphanum))]` sequence, throw a *RangeError* exception.
         1. Set _opt_.[[co]] to _collation_.
         1. Let _hc_ be ? GetOption(_options_, `"hourCycle"`, `"string"`, &laquo; `"h11"`, `"h12"`, `"h23"`, `"h24"` &raquo;, *undefined*).
         1. Set _opt_.[[hc]] to _hc_.
@@ -224,6 +230,8 @@ contributors: Mozilla, Ecma International
         1. If _kn_ is not *undefined*, set _kn_ to ! ToString(_kn_).
         1. Set _opt_.[[kn]] to _kn_.
         1. Let _numberingSystem_ be ? GetOption(_options_, `"numberingSystem"`, `"string"`, *undefined*, *undefined*).
+        1. If _numberingSystem_ is not *undefined*, then
+          1. If _numberingSystem_ does not match the `[(3*8alphanum) *("-" (3*8alphanum))]` sequence, throw a *RangeError* exception.
         1. Set _opt_.[[nu]] to _numeringSystem_.
         1. Let _r_ be ! ApplyUnicodeExtensionToTag(_tag_, _opt_, _relevantExtensionKeys_).
         1. Set _locale_.[[Locale]] to _r_.[[locale]].


### PR DESCRIPTION
At the minimum we want to restrict the Unicode extension options to match the syntax `[(3*8alphanum) *("-" (3*8alphanum))]`, which is the syntax for Unicode extension `type` values per http://www.unicode.org/reports/tr35/#Unicode_locale_identifier. The `[(3*8alphanum) *("-" (3*8alphanum))]` syntax was used because we already refer to the RFC 5646 ABNF in other parts of this proposal.

In #19, we may or may not further restrict the possible values for 'calendar', 'collation', and 'numberingSystem', but this is the minimum restriction we need to apply in any case.
