### PR TITLE
Handle regular grandfathered language tags

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -27,13 +27,15 @@ contributors: Mozilla, Ecma International
         1. Let _language_ be ? GetOption(_options_, `"language"`, `"string"`, *undefined*, *undefined*).
         1. If _language_ is not *undefined*, then
           1. If _language_ does not match the `language` production, throw a *RangeError* exception.
+          1. If _language_ matches the `grandfathered` production, throw a *RangeError* exception.
         1. Let _script_ be ? GetOption(_options_, `"script"`, `"string"`, *undefined*, *undefined*).
         1. If _script_ is not *undefined*, then
           1. If _script_ does not match the `script` production, throw a *RangeError* exception.
         1. Let _region_ be ? GetOption(_options_, `"region"`, `"string"`, *undefined*, *undefined*).
         1. If _region_ is not *undefined*, then
           1. If _region_ does not match the `region` production, throw a *RangeError* exception.
-        1. If _tag_ matches the `langtag` production, then
+        1. If _tag_ matches neither the `privateuse` nor the `grandfathered` production, then
+          1. Assert: _tag_ matches the `langtag` production.
           1. If _language_ is not *undefined*, then
             1. Set _tag_ to _tag_ with the substring corresponding to the `language` production replaced by the string _language_.
           1. If _script_ is not *undefined*, then
@@ -58,12 +60,13 @@ contributors: Mozilla, Ecma International
 
       <emu-alg>
         1. Assert: Type(_tag_) is String.
-        1. If _tag_ does not match the `langtag` production, then
+        1. If _tag_ matches the `privateuse` or the `grandfathered` production, then
           1. Let _result_ be a new Record.
           1. Repeat for each element _key_ of _relevantExtensionKeys_ in List order,
             1. Set result.[[<_key_>]] to *undefined*.
           1. Set _result_.[[locale]] to _tag_.
           1. Return _result_.
+        1. Assert: _tag_ matches the `langtag` production.
         1. If _tag_ contains a substring that is a Unicode locale extension sequence, then
           1. Let _extension_ be the String value consisting of the first substring of _tag_ that is a Unicode locale extension sequence.
           1. Let _components_ be ! UnicodeExtensionComponents(_extension_).
@@ -382,7 +385,8 @@ contributors: Mozilla, Ecma International
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
-        1. If _locale_ does not match the `langtag` production, return *undefined*.
+        1. If _locale_ matches the `privateuse` or the `grandfathered` production, return *undefined*.
+        1. Assert: _locale_ matches the `langtag` production.
         1. Return the substring of _locale_ corresponding to the `language` production.
       </emu-alg>
     </emu-clause>
@@ -395,7 +399,8 @@ contributors: Mozilla, Ecma International
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
-        1. If _locale_ does not match the `langtag` production, return *undefined*.
+        1. If _locale_ matches the `privateuse` or the `grandfathered` production, return *undefined*.
+        1. Assert: _locale_ matches the `langtag` production.
         1. If _locale_ does not contain the `["-" script]` sequence, return *undefined*.
         1. Return the substring of _locale_ corresponding to the `script` production.
       </emu-alg>
@@ -409,7 +414,8 @@ contributors: Mozilla, Ecma International
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
-        1. If _locale_ does not match the `langtag` production, return *undefined*.
+        1. If _locale_ matches the `privateuse` or the `grandfathered` production, return *undefined*.
+        1. Assert: _locale_ matches the `langtag` production.
         1. If _locale_ does not contain the `["-" region]` sequence, return *undefined*.
         1. Return the substring of _locale_ corresponding to the `region` production.
       </emu-alg>


### PR DESCRIPTION
As mentioned in #12, regular grandfathered tags also match the `langtag` production, so in order to properly detect all grandfathered tags, we need to change a few conditions to explicitly check for the `grandfathered` production. 

I've chosen the variant "If _tag_ matches neither the `privateuse` nor the `grandfathered` production" (plus an assertion that if that's the case, then `tag` matches the `langtag` production) instead of for example "If _tag_ matches the `langtag` production, but does not match the `grandfathered` production", so we explicitly mention all possible productions of the RFC 5646 start symbol `Language-Tag`. And mentioning all possible cases may remind implementers to handle exotic things like privateuse-only language tags correctly. :-)

Note: The check for the `"language"` option is necessary to detect grandfathered language tags like "no-bok" ("no-bok" also matches the `language` production!).