### PR TITLE
Remove unnecessary assignment to [[InitializedLocale]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -243,7 +243,6 @@ contributors: Mozilla, Ecma International
         1. If _relevantExtensionKeys_ contains `"kn"`, then
           1. Set _locale_.[[Numeric]] to _r_.[[kn]].
         1. Set _locale_.[[NumberingSystem]] to _r_.[[nu]].
-        1. Set _locale_.[[InitializedLocale]] to *true*.
         1. Return _locale_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
The value of the [[InitializedLocale]] slot is never read, only its present is tested, so we can remove the assignment to it. 

A similar change was performed for ECMA-402 in tc39/ecma402#181.