### PR TITLE
Normative: Add baseName getter

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -273,8 +273,8 @@ contributors: Mozilla, Ecma International
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
-        1. If _locale_ does not match the `langtag` production, return *undefined*.
-        1. Return the substring of _locale_ corresponding to the `language ["-" script] ["-" region]` subsequence of the `langtag` grammar.
+        1. If _locale_ does not match the `langtag` production, return _locale_.
+        1. Return the substring of _locale_ corresponding to the `language ["-" script] ["-" region] *("-" variant)` subsequence of the `langtag` grammar.
     </emu-clause>
 
     <emu-clause id="sec-Intl.Locale.prototype.collation">

--- a/spec.html
+++ b/spec.html
@@ -265,6 +265,18 @@ contributors: Mozilla, Ecma International
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-Intl.Locale.prototype.baseName">
+      <h1>get Intl.Locale.prototype.baseName</h1>
+      <p>`Intl.Locale.prototype.baseName` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="https://tools.ietf.org/html/rfc5646#section-2.1">RFC 5646's Language-Tag grammar</a>. Its get accessor function performs the following steps:</p>
+      <emu-alg>
+        1. Let _loc_ be the *this* value.
+        1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
+          1. Throw a *TypeError* exception.
+        1. Let _locale_ be _loc_.[[Locale]].
+        1. If _locale_ does not match the `langtag` production, return *undefined*.
+        1. Return the substring of _locale_ corresponding to the `language ["-" script] ["-" region]` subsequence of the `langtag` grammar.
+    </emu-clause>
+
     <emu-clause id="sec-Intl.Locale.prototype.collation">
       <h1>get Intl.Locale.prototype.collation</h1>
       <p>`Intl.Locale.prototype.collation` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>


### PR DESCRIPTION
The "base name" of a locale stands for the language-region-script
triple. This patch adds a baseName getter on Intl.Locale.prototype
to allow for easy access to this part of the locale.

Closes #22