### PR TITLE
Normative: Represent keywords in resolvedOptions().locale

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -571,7 +571,7 @@ contributors: Mozilla, Ecma International
             1. Let _displayValue_ be _value_.
           1. Otherwise, if _locale_.[[&lt;_key_&gt;]] is the empty string and _keyLocaleData_ contains `"true"`,
             1. Let _value_ be `"true"`.
-            1. Let _displayValue_ be *undefined*.
+            1. Let _displayValue_ be `"true"`.
           1. Otherwise,
             1. Let _value_ be _keyLocaleData_.[[0]].
             1. Let _displayValue_ be *undefined*.


### PR DESCRIPTION
This patch makes Unicode extension attributes be represented in
the resolvedOptions().locale, converted by keywords with the
value "true". For example,

new Intl.Collator("de-u-kn").resolvedOptions().locale

would be "de" without this patch, and "de-u-kn-true" with this patch.

Closes https://github.com/tc39/ecma402/issues/223