### PR TITLE
Normative: Define error recovery behavior for likely subtags

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -312,7 +312,7 @@ contributors: Mozilla, Ecma International
       1. Let _loc_ be the *this* value.
       1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
         1. Throw a *TypeError* exception.
-      1. Let _maximal_ be the result of the <a href="https://www.unicode.org/reports/tr35/#Likely_Subtags">Add Likely Subtags</a> algorithm applied to _loc_.[[Locale]].
+      1. Let _maximal_ be the result of the <a href="https://www.unicode.org/reports/tr35/#Likely_Subtags">Add Likely Subtags</a> algorithm applied to _loc_.[[Locale]]. If an error is signaled, set _maximal_ to _loc_.[[Locale]].
       1. Return ! Construct(%Locale%, _maximal_).
       </emu-alg>
     </emu-clause>
@@ -324,7 +324,7 @@ contributors: Mozilla, Ecma International
       1. Let _loc_ be the *this* value.
       1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
         1. Throw a *TypeError* exception.
-      1. Let _minimal_ be the result of the <a href="https://www.unicode.org/reports/tr35/#Likely_Subtags">Remove Likely Subtags</a> algorithm applied to _loc_.[[Locale]].
+      1. Let _minimal_ be the result of the <a href="https://www.unicode.org/reports/tr35/#Likely_Subtags">Remove Likely Subtags</a> algorithm applied to _loc_.[[Locale]]. If an error is signaled, set _minimal_ to _loc_.[[Locale]].
       1. Return ! Construct(%Locale%, _minimal_).
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
When Intl.Locale.prototype.maximize() and minimize() are called on
locales which don't appear in CLDR's database of known locales with
likely subtags, the semantics were previously unclear. With this
patch, a new, identical Locale object is returned.

These semantics encode the conclusion of the discussion in the
June 2018 Intl meeting.

Closes #42