### PR TITLE
Changes for InsertUnicodeExtension

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -173,8 +173,7 @@ contributors: Mozilla, Ecma International
           1. Let _preExtension_ be the substring of _locale_ from position 0, inclusive, to position _privateIndex_, exclusive.
           1. Let _postExtension_ be the substring of _locale_ from position _privateIndex_ to the end of the string.
           1. Let _locale_ be the string-concatenation of _preExtension_, _extension_, and _postExtension_.
-        1. Assert: IsStructurallyValidLanguageTag(_locale_) is *true*.
-        1. Return ! CanonicalizeLanguageTag(_locale_).
+        1. Return _locale_.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -106,7 +106,7 @@ contributors: Mozilla, Ecma International
         1. Let _locale_ be the String value that is _tag_ with all Unicode locale extension sequences removed.
         1. Let _newExtension_ be the canonicalized Unicode BCP 47 U Extension based on _attributes_ and _keywords_ as defined in <a href="https://www.unicode.org/reports/tr35/#u_Extension">UTS #35 section 3.6</a>.
         1. If _newExtension_ is not the empty String, then
-          1. Let _locale_ be ? InsertUnicodeExtension(_locale_, _newExtension_).
+          1. Let _locale_ be InsertUnicodeExtension(_locale_, _newExtension_).
         1. Set _result_.[[locale]] to _locale_.
         1. Return _result_.
       </emu-alg>
@@ -161,9 +161,9 @@ contributors: Mozilla, Ecma International
       </p>
 
       <emu-alg>
+        1. Assert: _locale_ matches neither the `privateuse` nor the `grandfathered` production.
         1. Assert: _locale_ does not contain a substring that is a Unicode locale extension sequence.
         1. Assert: _extension_ is a Unicode extension sequence.
-        1. If _locale_ matches the `privateuse` or the `grandfathered` production, throw a *RangeError* exception.
         1. Let _privateIndex_ be ! Call(%StringProto_indexOf%, _locale_, &laquo; `"-x-"` &raquo;).
         1. If _privateIndex_ = -1, then
           1. Let _locale_ be the concatenation of _locale_ and _extension_.

--- a/spec.html
+++ b/spec.html
@@ -103,10 +103,12 @@ contributors: Mozilla, Ecma International
             1. Else,
               1. Append the Record{[[Key]]: _key_, [[Value]]: _value_} to _keywords_.
           1. Set _result_.[[<_key_>]] to _value_.
-        1. Let _locale_ be the String value that is _tag_ with all Unicode locale extension sequences removed.
-        1. Let _newExtension_ be the canonicalized Unicode BCP 47 U Extension based on _attributes_ and _keywords_ as defined in <a href="https://www.unicode.org/reports/tr35/#u_Extension">UTS #35 section 3.6</a>.
-        1. If _newExtension_ is not the empty String, then
+        1. If _attributes_ is not empty or _keywords_ is not empty, then
+          1. Let _locale_ be the String value that is _tag_ with all Unicode locale extension sequences removed.
+          1. Let _newExtension_ be the canonicalized Unicode BCP 47 U Extension based on _attributes_ and _keywords_ as defined in <a href="https://www.unicode.org/reports/tr35/#u_Extension">UTS #35 section 3.6</a>.
           1. Let _locale_ be InsertUnicodeExtension(_locale_, _newExtension_).
+        1. Else,
+          1. Let _locale_ be _tag_.
         1. Set _result_.[[locale]] to _locale_.
         1. Return _result_.
       </emu-alg>


### PR DESCRIPTION
e9155f38bcfae928e6b94ee027e38034a66cf8d4
- Fix for #56 

ce7e711c274f648eb2e28dc9a6513474964a249e
- Creating a Unicode extension when `attributes` and `keywords` are both empty could be misunderstood resp. may not necessarily imply the resulting string is the empty string, so change the condition to check for non-empty `attributes` and `keywords` lists.

5bf56ba3b0c0c5d72a43bca1de2494d2e363c07a
- Calling `CanonicalizeLanguageTag` is no longer needed now that the caller already passes a canonicalized Unicode extension sequence.
