### PR TITLE
Normative: Simplify algorithms, without privateuse/grandfathered tags

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35,29 +35,20 @@ contributors: Mozilla, Ecma International
         1. Let _region_ be ? GetOption(_options_, `"region"`, `"string"`, *undefined*, *undefined*).
         1. If _region_ is not *undefined*, then
           1. If _region_ does not match the `region` production, throw a *RangeError* exception.
-        1. If _tag_ matches the `grandfathered` production,
-          1. Set _tag_ to CanonicalizeLanguageTag(_tag_).
+        1. Set _tag_ to CanonicalizeLanguageTag(_tag_).
         1. If _language_ is not *undefined*,
-          1. If _tag_ matches the `privateuse` or `grandfathered` production,
-            1. Set _tag_ to _language_.
-            1. If _tag_ matches the `grandfathered` production,
-              1. Set _tag_ to CanonicalizeLanguageTag(_tag_).
+          1. Assert: _tag_ matches the `langtag` production.
+          1. Set _tag_ to _tag_ with the substring corresponding to the `language` production replaced by the string _language_.
+        1. If _script_ is not *undefined*, then
+          1. If _tag_ does not contain a `script` production, then
+            1. Set _tag_ to the concatenation of the `language` production of _tag_, `"-"`, _script_, and the rest of _tag_.
           1. Else,
-            1. Assert: _tag_ matches the `langtag` production.
-            1. Set _tag_ to _tag_ with the substring corresponding to the `language` production replaced by the string _language_.
-        1. If _tag_ matches the `privateuse` or `grandfathered` production,
-          1. If _script_ is not *undefined*, or if _region_ is not *undefined*, throw a *RangeError* exception.
-        1. Else,
-          1. If _script_ is not *undefined*, then
-            1. If _tag_ does not contain a `script` production, then
-              1. Set _tag_ to the concatenation of the `language` production of _tag_, `"-"`, _script_, and the rest of _tag_.
-            1. Else,
-              1. Set _tag_ to _tag_ with the substring corresponding to the `script` production replaced by the string _script_.
-          1. If _region_ is not *undefined*, then
-            1. If _tag_ does not contain a `region` production, then
-              1. Set _tag_ to the concatenation of the `language` production of _tag_, the substring corresponding to the `"-" script` production if present, `"-"`, _region_, and the rest of _tag_.
-            1. Else,
-              1. Set _tag_ to _tag_ with the substring corresponding to the `region` production replaced by the string _region_.
+            1. Set _tag_ to _tag_ with the substring corresponding to the `script` production replaced by the string _script_.
+        1. If _region_ is not *undefined*, then
+          1. If _tag_ does not contain a `region` production, then
+            1. Set _tag_ to the concatenation of the `language` production of _tag_, the substring corresponding to the `"-" script` production if present, `"-"`, _region_, and the rest of _tag_.
+          1. Else,
+            1. Set _tag_ to _tag_ with the substring corresponding to the `region` production replaced by the string _region_.
         1. Return CanonicalizeLanguageTag(_tag_).
       </emu-alg>
     </emu-clause>
@@ -70,12 +61,6 @@ contributors: Mozilla, Ecma International
 
       <emu-alg>
         1. Assert: Type(_tag_) is String.
-        1. If _tag_ matches the `privateuse` or the `grandfathered` production, then
-          1. Let _result_ be a new Record.
-          1. Repeat for each element _key_ of _relevantExtensionKeys_ in List order,
-            1. Set result.[[<_key_>]] to *undefined*.
-          1. Set _result_.[[locale]] to _tag_.
-          1. Return _result_.
         1. Assert: _tag_ matches the `langtag` production.
         1. If _tag_ contains a substring that is a Unicode locale extension sequence, then
           1. Let _extension_ be the String value consisting of the first substring of _tag_ that is a Unicode locale extension sequence.
@@ -163,7 +148,7 @@ contributors: Mozilla, Ecma International
       <emu-alg>
         1. Assert: _locale_ does not contain a substring that is a Unicode locale extension sequence.
         1. Assert: _extension_ is a Unicode extension sequence.
-        1. If _locale_ matches the `privateuse` or the `grandfathered` production, throw a *RangeError* exception.
+        1. Assert: _tag_ matches the `langtag` production.
         1. Let _privateIndex_ be ! Call(%StringProto_indexOf%, _locale_, &laquo; `"-x-"` &raquo;).
         1. If _privateIndex_ = -1, then
           1. Let _locale_ be the concatenation of _locale_ and _extension_.
@@ -416,7 +401,6 @@ contributors: Mozilla, Ecma International
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
-        1. If _locale_ matches the `privateuse` or the `grandfathered` production, return _locale_.
         1. Assert: _locale_ matches the `langtag` production.
         1. Return the substring of _locale_ corresponding to the `language` production.
       </emu-alg>
@@ -430,7 +414,6 @@ contributors: Mozilla, Ecma International
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
-        1. If _locale_ matches the `privateuse` or the `grandfathered` production, return *undefined*.
         1. Assert: _locale_ matches the `langtag` production.
         1. If _locale_ does not contain the `["-" script]` sequence, return *undefined*.
         1. Return the substring of _locale_ corresponding to the `script` production.
@@ -445,7 +428,6 @@ contributors: Mozilla, Ecma International
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
-        1. If _locale_ matches the `privateuse` or the `grandfathered` production, return *undefined*.
         1. Assert: _locale_ matches the `langtag` production.
         1. If _locale_ does not contain the `["-" region]` sequence, return *undefined*.
         1. Return the substring of _locale_ corresponding to the `region` production.


### PR DESCRIPTION
Based on Unicode BCP 47 Locale Identifier conversion, adopted in
https://github.com/tc39/ecma402/pull/289 , there will be no
privateuse or grandfathered locales, allowing this specification's
definition of ApplyOptionsToTag and other algorithms to be simplified.

Relates to #63