### PR TITLE
Change the ref grammar from RFC5646 to UTS35

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -36,7 +36,7 @@ contributors: Mozilla, Ecma International
           1. If _region_ does not match the `unicode_region_subtag` production, throw a *RangeError* exception.
         1. Set _tag_ to CanonicalizeLanguageTag(_tag_).
         1. If _language_ is not *undefined*,
-          1. Assert: _tag_ matches the `unicode_language_id` production.
+          1. Assert: _tag_ matches the `unicode_locale_id` production.
           1. Set _tag_ to _tag_ with the substring corresponding to the `unicode_language_subtag` production replaced by the string _language_.
         1. If _script_ is not *undefined*, then
           1. If _tag_ does not contain a `unicode_script_subtag` production, then
@@ -60,7 +60,7 @@ contributors: Mozilla, Ecma International
 
       <emu-alg>
         1. Assert: Type(_tag_) is String.
-        1. Assert: _tag_ matches the `unicode_language_id` production.
+        1. Assert: _tag_ matches the `unicode_locale_id` production.
         1. If _tag_ contains a substring that is a Unicode locale extension sequence, then
           1. Let _extension_ be the String value consisting of the first substring of _tag_ that is a Unicode locale extension sequence.
           1. Let _components_ be ! UnicodeExtensionComponents(_extension_).
@@ -147,7 +147,7 @@ contributors: Mozilla, Ecma International
       <emu-alg>
         1. Assert: _locale_ does not contain a substring that is a Unicode locale extension sequence.
         1. Assert: _extension_ is a Unicode extension sequence.
-        1. Assert: _tag_ matches the `unicode_language_id` production.
+        1. Assert: _tag_ matches the `unicode_locale_id` production.
         1. Let _privateIndex_ be ! Call(%StringProto_indexOf%, _locale_, &laquo; `"-x-"` &raquo;).
         1. If _privateIndex_ = -1, then
           1. Let _locale_ be the concatenation of _locale_ and _extension_.
@@ -320,7 +320,7 @@ contributors: Mozilla, Ecma International
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
-        1. If _locale_ does not match the `unicode_language_id` production, return _locale_.
+        1. If _locale_ does not match the `unicode_locale_id` production, return _locale_.
         1. Return the substring of _locale_ corresponding to the `language ["-" script] ["-" region] *("-" variant)` subsequence of the `unicode_language_id` grammar.
     </emu-clause>
 
@@ -400,7 +400,7 @@ contributors: Mozilla, Ecma International
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
-        1. Assert: _locale_ matches the `unicode_language_id` production.
+        1. Assert: _locale_ matches the `unicode_locale_id` production.
         1. Return the substring of _locale_ corresponding to the `unicode_language_subtag` production.
       </emu-alg>
     </emu-clause>
@@ -413,7 +413,7 @@ contributors: Mozilla, Ecma International
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
-        1. Assert: _locale_ matches the `unicode_language_id` production.
+        1. Assert: _locale_ matches the `unicode_locale_id` production.
         1. If _locale_ does not contain the `["-" script]` sequence, return *undefined*.
         1. Return the substring of _locale_ corresponding to the `unicode_script_subtag` production.
       </emu-alg>
@@ -427,7 +427,7 @@ contributors: Mozilla, Ecma International
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
-        1. Assert: _locale_ matches the `unicode_language_id` production.
+        1. Assert: _locale_ matches the `unicode_locale_id` production.
         1. If _locale_ does not contain the `["-" region]` sequence, return *undefined*.
         1. Return the substring of _locale_ corresponding to the `unicode_region_subtag` production.
       </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -141,7 +141,7 @@ contributors: Mozilla, Ecma International
         The InsertUnicodeExtension abstract operation inserts _extension_, which must be a Unicode locale extension sequence, into _locale_, which must be a String value with a structurally valid and canonicalized BCP 47 language tag. The following steps are taken:
       </p>
       <p>
-        The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
+        The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
       </p>
 
       <emu-alg>
@@ -164,7 +164,7 @@ contributors: Mozilla, Ecma International
       <h1>Intl.Locale( _tag_ [, _options_] )</h1>
 
       <p>
-        The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
+        The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
 
         When the *Intl.Locale* function is called with an argument _tag_ and an optional argument _options_, the following steps are taken:
       </p>
@@ -314,7 +314,7 @@ contributors: Mozilla, Ecma International
 
     <emu-clause id="sec-Intl.Locale.prototype.baseName">
       <h1>get Intl.Locale.prototype.baseName</h1>
-      <p>`Intl.Locale.prototype.baseName` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. Its get accessor function performs the following steps:</p>
+      <p>`Intl.Locale.prototype.baseName` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
@@ -394,7 +394,7 @@ contributors: Mozilla, Ecma International
 
     <emu-clause id="sec-Intl.Locale.prototype.language">
       <h1>get Intl.Locale.prototype.language</h1>
-      <p>`Intl.Locale.prototype.language` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. Its get accessor function performs the following steps:</p>
+      <p>`Intl.Locale.prototype.language` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
@@ -407,7 +407,7 @@ contributors: Mozilla, Ecma International
 
     <emu-clause id="sec-Intl.Locale.prototype.script">
       <h1>get Intl.Locale.prototype.script</h1>
-      <p>`Intl.Locale.prototype.script` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. Its get accessor function performs the following steps:</p>
+      <p>`Intl.Locale.prototype.script` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
@@ -421,7 +421,7 @@ contributors: Mozilla, Ecma International
 
     <emu-clause id="sec-Intl.Locale.prototype.region">
       <h1>get Intl.Locale.prototype.region</h1>
-      <p>`Intl.Locale.prototype.region` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. Its get accessor function performs the following steps:</p>
+      <p>`Intl.Locale.prototype.region` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then

--- a/spec.html
+++ b/spec.html
@@ -19,7 +19,7 @@ contributors: Mozilla, Ecma International
     <emu-clause id="sec-apply-options-to-tag" aoid=ApplyOptionsToTag>
       <h1>ApplyOptionsToTag( _tag_, _options_ )</h1>
       <p>
-        The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
+        The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
       </p>
 
       <emu-alg>
@@ -55,7 +55,7 @@ contributors: Mozilla, Ecma International
     <emu-clause id="sec-apply-unicode-extension-to-tag" aoid=ApplyUnicodeExtensionToTag>
       <h1>ApplyUnicodeExtensionToTag( _tag_, _options_, _relevantExtensionKeys_ )</h1>
       <p>
-        The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
+        The following algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
       </p>
 
       <emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -19,7 +19,7 @@ contributors: Mozilla, Ecma International
     <emu-clause id="sec-apply-options-to-tag" aoid=ApplyOptionsToTag>
       <h1>ApplyOptionsToTag( _tag_, _options_ )</h1>
       <p>
-        The following algorithm refers to <a href="https://tools.ietf.org/html/rfc5646#section-2.1">RFC 5646's Language-Tag grammar</a>.
+        The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
       </p>
 
       <emu-alg>
@@ -27,28 +27,27 @@ contributors: Mozilla, Ecma International
         1. If IsStructurallyValidLanguageTag(_tag_) is *false*, throw a *RangeError* exception.
         1. Let _language_ be ? GetOption(_options_, `"language"`, `"string"`, *undefined*, *undefined*).
         1. If _language_ is not *undefined*, then
-          1. If _language_ does not match the `language` production, throw a *RangeError* exception.
-          1. If _language_ matches the `grandfathered` production, throw a *RangeError* exception.
-        1. Let _script_ be ? GetOption(_options_, `"script"`, `"string"`, *undefined*, *undefined*).
+          1. If _language_ does not match the `unicode_language_subtag` production, throw a *RangeError* exception.
+        1. Let _script_ be ? GetOption(_options_, `"unicode_script_subtag"`, `"string"`, *undefined*, *undefined*).
         1. If _script_ is not *undefined*, then
-          1. If _script_ does not match the `script` production, throw a *RangeError* exception.
+          1. If _script_ does not match the `unicode_script_subtag` production, throw a *RangeError* exception.
         1. Let _region_ be ? GetOption(_options_, `"region"`, `"string"`, *undefined*, *undefined*).
         1. If _region_ is not *undefined*, then
-          1. If _region_ does not match the `region` production, throw a *RangeError* exception.
+          1. If _region_ does not match the `unicode_region_subtag` production, throw a *RangeError* exception.
         1. Set _tag_ to CanonicalizeLanguageTag(_tag_).
         1. If _language_ is not *undefined*,
-          1. Assert: _tag_ matches the `langtag` production.
-          1. Set _tag_ to _tag_ with the substring corresponding to the `language` production replaced by the string _language_.
+          1. Assert: _tag_ matches the `unicode_language_id` production.
+          1. Set _tag_ to _tag_ with the substring corresponding to the `unicode_language_subtag` production replaced by the string _language_.
         1. If _script_ is not *undefined*, then
-          1. If _tag_ does not contain a `script` production, then
-            1. Set _tag_ to the concatenation of the `language` production of _tag_, `"-"`, _script_, and the rest of _tag_.
+          1. If _tag_ does not contain a `unicode_script_subtag` production, then
+            1. Set _tag_ to the concatenation of the `unicode_language_subtag` production of _tag_, `"-"`, _script_, and the rest of _tag_.
           1. Else,
-            1. Set _tag_ to _tag_ with the substring corresponding to the `script` production replaced by the string _script_.
+            1. Set _tag_ to _tag_ with the substring corresponding to the `unicode_script_subtag` production replaced by the string _script_.
         1. If _region_ is not *undefined*, then
-          1. If _tag_ does not contain a `region` production, then
-            1. Set _tag_ to the concatenation of the `language` production of _tag_, the substring corresponding to the `"-" script` production if present, `"-"`, _region_, and the rest of _tag_.
+          1. If _tag_ does not contain a `unicode_region_subtag` production, then
+            1. Set _tag_ to the concatenation of the `unicode_language_subtag` production of _tag_, the substring corresponding to the `"-" unicode_script_subtag` production if present, `"-"`, _region_, and the rest of _tag_.
           1. Else,
-            1. Set _tag_ to _tag_ with the substring corresponding to the `region` production replaced by the string _region_.
+            1. Set _tag_ to _tag_ with the substring corresponding to the `unicode_region_subtag` production replaced by the string _region_.
         1. Return CanonicalizeLanguageTag(_tag_).
       </emu-alg>
     </emu-clause>
@@ -56,12 +55,12 @@ contributors: Mozilla, Ecma International
     <emu-clause id="sec-apply-unicode-extension-to-tag" aoid=ApplyUnicodeExtensionToTag>
       <h1>ApplyUnicodeExtensionToTag( _tag_, _options_, _relevantExtensionKeys_ )</h1>
       <p>
-        The following algorithm refers to <a href="https://tools.ietf.org/html/rfc5646#section-2.1">RFC 5646's Language-Tag grammar</a>.
+        The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
       </p>
 
       <emu-alg>
         1. Assert: Type(_tag_) is String.
-        1. Assert: _tag_ matches the `langtag` production.
+        1. Assert: _tag_ matches the `unicode_language_id` production.
         1. If _tag_ contains a substring that is a Unicode locale extension sequence, then
           1. Let _extension_ be the String value consisting of the first substring of _tag_ that is a Unicode locale extension sequence.
           1. Let _components_ be ! UnicodeExtensionComponents(_extension_).
@@ -142,13 +141,13 @@ contributors: Mozilla, Ecma International
         The InsertUnicodeExtension abstract operation inserts _extension_, which must be a Unicode locale extension sequence, into _locale_, which must be a String value with a structurally valid and canonicalized BCP 47 language tag. The following steps are taken:
       </p>
       <p>
-        The following algorithm refers to <a href="https://tools.ietf.org/html/rfc5646#section-2.1">RFC 5646's Language-Tag grammar</a>.
+        The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
       </p>
 
       <emu-alg>
         1. Assert: _locale_ does not contain a substring that is a Unicode locale extension sequence.
         1. Assert: _extension_ is a Unicode extension sequence.
-        1. Assert: _tag_ matches the `langtag` production.
+        1. Assert: _tag_ matches the `unicode_language_id` production.
         1. Let _privateIndex_ be ! Call(%StringProto_indexOf%, _locale_, &laquo; `"-x-"` &raquo;).
         1. If _privateIndex_ = -1, then
           1. Let _locale_ be the concatenation of _locale_ and _extension_.
@@ -165,7 +164,7 @@ contributors: Mozilla, Ecma International
       <h1>Intl.Locale( _tag_ [, _options_] )</h1>
 
       <p>
-        The following algorithm refers to <a href="https://tools.ietf.org/html/rfc5646#section-2.1">RFC 5646's Language-Tag grammar</a>.
+        The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>.
 
         When the *Intl.Locale* function is called with an argument _tag_ and an optional argument _options_, the following steps are taken:
       </p>
@@ -315,14 +314,14 @@ contributors: Mozilla, Ecma International
 
     <emu-clause id="sec-Intl.Locale.prototype.baseName">
       <h1>get Intl.Locale.prototype.baseName</h1>
-      <p>`Intl.Locale.prototype.baseName` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="https://tools.ietf.org/html/rfc5646#section-2.1">RFC 5646's Language-Tag grammar</a>. Its get accessor function performs the following steps:</p>
+      <p>`Intl.Locale.prototype.baseName` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
-        1. If _locale_ does not match the `langtag` production, return _locale_.
-        1. Return the substring of _locale_ corresponding to the `language ["-" script] ["-" region] *("-" variant)` subsequence of the `langtag` grammar.
+        1. If _locale_ does not match the `unicode_language_id` production, return _locale_.
+        1. Return the substring of _locale_ corresponding to the `language ["-" script] ["-" region] *("-" variant)` subsequence of the `unicode_language_id` grammar.
     </emu-clause>
 
     <emu-clause id="sec-Intl.Locale.prototype.calendar">
@@ -395,42 +394,42 @@ contributors: Mozilla, Ecma International
 
     <emu-clause id="sec-Intl.Locale.prototype.language">
       <h1>get Intl.Locale.prototype.language</h1>
-      <p>`Intl.Locale.prototype.language` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="https://tools.ietf.org/html/rfc5646#section-2.1">RFC 5646's Language-Tag grammar</a>. Its get accessor function performs the following steps:</p>
+      <p>`Intl.Locale.prototype.language` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
-        1. Assert: _locale_ matches the `langtag` production.
-        1. Return the substring of _locale_ corresponding to the `language` production.
+        1. Assert: _locale_ matches the `unicode_language_id` production.
+        1. Return the substring of _locale_ corresponding to the `unicode_language_subtag` production.
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-Intl.Locale.prototype.script">
       <h1>get Intl.Locale.prototype.script</h1>
-      <p>`Intl.Locale.prototype.script` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="https://tools.ietf.org/html/rfc5646#section-2.1">RFC 5646's Language-Tag grammar</a>. Its get accessor function performs the following steps:</p>
+      <p>`Intl.Locale.prototype.script` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
-        1. Assert: _locale_ matches the `langtag` production.
+        1. Assert: _locale_ matches the `unicode_language_id` production.
         1. If _locale_ does not contain the `["-" script]` sequence, return *undefined*.
-        1. Return the substring of _locale_ corresponding to the `script` production.
+        1. Return the substring of _locale_ corresponding to the `unicode_script_subtag` production.
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-Intl.Locale.prototype.region">
       <h1>get Intl.Locale.prototype.region</h1>
-      <p>`Intl.Locale.prototype.region` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="https://tools.ietf.org/html/rfc5646#section-2.1">RFC 5646's Language-Tag grammar</a>. Its get accessor function performs the following steps:</p>
+      <p>`Intl.Locale.prototype.region` is an accessor property whose set accessor function is *undefined*. The following algorithm refers to <a href="http://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. Its get accessor function performs the following steps:</p>
       <emu-alg>
         1. Let _loc_ be the *this* value.
         1. If Type(_loc_) is not Object or _loc_ does not have an [[InitializedLocale]] internal slot, then
           1. Throw a *TypeError* exception.
         1. Let _locale_ be _loc_.[[Locale]].
-        1. Assert: _locale_ matches the `langtag` production.
+        1. Assert: _locale_ matches the `unicode_language_id` production.
         1. If _locale_ does not contain the `["-" region]` sequence, return *undefined*.
-        1. Return the substring of _locale_ corresponding to the `region` production.
+        1. Return the substring of _locale_ corresponding to the `unicode_region_subtag` production.
       </emu-alg>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
This is following up https://github.com/tc39/proposal-intl-locale/issues/63 after the merging of https://github.com/tc39/proposal-intl-locale/pull/66

1. Change all the links from pointing to RFC5646 to pointing to UTS35 instead.
2. In Intl.Locale.prototype.baseName change langtag production -> unicode_language_id production.
3. Change all other  'XXX production' based on RFC5646 to 'YYY production' based on UTS35 
  a. language production -> unicode_language_subtag production
  b. script production -> unicode_script_subtag production
  c. region production -> unicode_region_subtag production
  d. langtag production -> unicode_locale_id production (note: except 2 above)
  e. Remove the reference of "grandfathered production" (see 4 below)
4. Merge the step 4.a "If language does not match the language production, throw a RangeError exception." step 4.b "If language matches the grandfathered production, throw a RangeError exception." of ApplyOptionsToTag as only one 4.a "If language does not match the unicode_language_subtag  production, throw a RangeError exception." since the definition of unicode_language_subtag in UTS35 already excluded ("4ALPHA" or  "2*3ALPHA '-' extlang") and therefore all language which match grandfathered production is already "not match unicode_language_subtag)

@littledan @gsathya @zbraniecki @anba @macchiati @jungshik @aphillips @markusicu @nciric 

