### PR TITLE
correct option unicode_script_subtag to "script"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28,7 +28,7 @@ contributors: Mozilla, Ecma International
         1. Let _language_ be ? GetOption(_options_, `"language"`, `"string"`, *undefined*, *undefined*).
         1. If _language_ is not *undefined*, then
           1. If _language_ does not match the `unicode_language_subtag` production, throw a *RangeError* exception.
-        1. Let _script_ be ? GetOption(_options_, `"unicode_script_subtag"`, `"string"`, *undefined*, *undefined*).
+        1. Let _script_ be ? GetOption(_options_, `"script"`, `"string"`, *undefined*, *undefined*).
         1. If _script_ is not *undefined*, then
           1. If _script_ does not match the `unicode_script_subtag` production, throw a *RangeError* exception.
         1. Let _region_ be ? GetOption(_options_, `"region"`, `"string"`, *undefined*, *undefined*).


### PR DESCRIPTION
@littledan 