### PR TITLE
CanonicalizeUnicodeLocaleId should perform only step 1 of BCP 47 Language Tag to Unicode BCP 47 Locale Identifier algo.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -451,7 +451,7 @@ contributors: Mozilla, Ecma International
       </p>
 
       <emu-alg>
-        1. <ins>Let _localeId_ be the string _locale_ after performing the steps specified in the &ldquo;<a href="https://www.unicode.org/reports/tr35/tr35.html#Language_Tag_to_Locale_Identifier">BCP 47 Language Tag to Unicode BCP 47 Locale Identifier</a>&rdquo; algorithm, from <a href="https://unicode.org/reports/tr35/#BCP_47_Language_Tag_Conversion">Unicode Technical Standard #35 LDML § 3.3.1 BCP 47 Language Tag Conversion</a>, on it.  (The result is a Unicode BCP 47 locale identifier, in canonical syntax but not necessarily in canonical form.)
+        1. <ins>Let _localeId_ be the string _locale_ after performing the first step specified in the &ldquo;<a href="https://www.unicode.org/reports/tr35/tr35.html#Language_Tag_to_Locale_Identifier">BCP 47 Language Tag to Unicode BCP 47 Locale Identifier</a>&rdquo; algorithm, from <a href="https://unicode.org/reports/tr35/#BCP_47_Language_Tag_Conversion">Unicode Technical Standard #35 LDML § 3.3.1 BCP 47 Language Tag Conversion</a>, on it.  (The result is a Unicode BCP 47 locale identifier, in canonical syntax but not necessarily in canonical form.)
         1. <ins>Let _localeId_ be the string _localeId_ after performing the algorithm to <a href="https://unicode.org/reports/tr35/#Canonical_Unicode_Locale_Identifiers">transform it to canonical form</a>.  (The result is a Unicode BCP 47 locale identifier, in both canonical syntax and canonical form.)
         1. <ins>If _localeId_ contains a substring _extension_ that is a Unicode locale extension sequence, then
           1. <ins>Let _components_ be ! UnicodeExtensionComponents(_extension_).


### PR DESCRIPTION
Fixes #97.

@jswalden @anba - r?